### PR TITLE
fix: update CI workflow to use 'develop' branch instead of 'dev'

### DIFF
--- a/tests/Feature/github/workflows/ci.yml
+++ b/tests/Feature/github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev", "master" ]
+    branches: [ "develop", "master" ]
   pull_request:
-    branches: [ "dev", "master" ]
+    branches: [ "develop", "master" ]
 
 jobs:
   tests:


### PR DESCRIPTION
fix: update CI workflow to use 'develop' branch instead of 'dev'