### PR TITLE
feat: add development server configuration to OpenAPI documentation

### DIFF
--- a/app/OpenApi/OpenApiSpec.php
+++ b/app/OpenApi/OpenApiSpec.php
@@ -16,6 +16,11 @@ use OpenApi\Attributes as OA;
   description: "Servidor Local"
 )]
 
+#[OA\Server(
+  url: "http://138.197.100.197/api/v1",
+  description: "Servidor de desarrollo"
+)]
+
 #[OA\SecurityScheme(
   securityScheme: "sanctum",
   type: "apiKey",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -12,6 +12,10 @@
         {
             "url": "http://localhost/api/v1",
             "description": "Servidor Local"
+        },
+        {
+            "url": "http://138.197.100.197/api/v1",
+            "description": "Servidor de desarrollo"
         }
     ],
     "paths": {


### PR DESCRIPTION
- Introduced a new server entry for the development environment in OpenApiSpec.php.
- Updated api-docs.json to include the development server URL and description.