### PR TITLE
feat: add Roles and Permissions CRUD with sync-permissions endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/PermissionController.php
+++ b/app/Http/Controllers/Api/V1/Admin/PermissionController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
+use Spatie\Permission\Models\Permission;
+
+class PermissionController extends Controller
+{
+    #[OA\Get(
+        path: '/admin/permissions',
+        summary: 'Listar permisos',
+        description: 'Retorna todos los permisos disponibles en el sistema, agrupados por recurso.',
+        operationId: 'permissionIndex',
+        security: [['sanctum' => []]],
+        tags: ['Permissions']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Listado de permisos obtenido correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Listado de permisos obtenido correctamente.'),
+                        new OA\Property(
+                            property: 'data',
+                            type: 'object',
+                            example: ['stores' => ['stores.view', 'stores.create'], 'users' => ['users.view']]
+                        ),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No autenticado.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object', example: ['auth' => ['Token inválido o ausente']]),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function index(): JsonResponse
+    {
+        $permissions = Permission::all()->groupBy(function ($permission) {
+            $parts = explode('.', $permission->name);
+
+            return $parts[0];
+        })->map(function ($group) {
+            return $group->pluck('name')->values();
+        });
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Listado de permisos obtenido correctamente.',
+            'data' => $permissions,
+            'errors' => null,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Admin/RoleController.php
+++ b/app/Http/Controllers/Api/V1/Admin/RoleController.php
@@ -1,0 +1,664 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Admin\CreateRoleRequest;
+use App\Http\Requests\Api\V1\Admin\SyncPermissionsRequest;
+use App\Http\Requests\Api\V1\Admin\UpdateRoleRequest;
+use App\Http\Resources\RoleResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use OpenApi\Attributes as OA;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class RoleController extends Controller
+{
+    #[OA\Get(
+        path: '/admin/roles',
+        summary: 'Listar roles',
+        description: 'Retorna la lista paginada de roles con conteo de usuarios y permisos.',
+        operationId: 'roleIndex',
+        security: [['sanctum' => []]],
+        tags: ['Roles']
+    )]
+    #[OA\Parameter(name: 'per_page', in: 'query', required: false, description: 'Resultados por página (default: 15)', schema: new OA\Schema(type: 'integer', example: 15))]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, description: 'Número de página', schema: new OA\Schema(type: 'integer', example: 1))]
+    #[OA\Response(
+        response: 200,
+        description: 'Listado de roles obtenido correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Listado de roles obtenido correctamente.'),
+                        new OA\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OA\Property(property: 'items', type: 'array', items: new OA\Items(ref: '#/components/schemas/Role')),
+                                new OA\Property(property: 'total', type: 'integer', example: 5),
+                                new OA\Property(property: 'per_page', type: 'integer', example: 15),
+                                new OA\Property(property: 'current_page', type: 'integer', example: 1),
+                                new OA\Property(property: 'last_page', type: 'integer', example: 1),
+                            ]
+                        ),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No autenticado.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object', example: ['auth' => ['Token inválido o ausente']]),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = $request->integer('per_page', 15);
+
+        $modelHasRolesTable = config('permission.table_names.model_has_roles', 'model_has_roles');
+
+        $roles = Role::withCount('permissions')
+            ->with('permissions')
+            ->paginate($perPage);
+
+        $roleIds = $roles->pluck('id');
+        $usersCounts = DB::table($modelHasRolesTable)
+            ->whereIn('role_id', $roleIds)
+            ->selectRaw('role_id, count(*) as aggregate')
+            ->groupBy('role_id')
+            ->pluck('aggregate', 'role_id');
+
+        $items = $roles->items();
+        foreach ($items as $role) {
+            $role->users_count = $usersCounts->get($role->id, 0);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Listado de roles obtenido correctamente.',
+            'data' => [
+                'items' => RoleResource::collection($items),
+                'total' => $roles->total(),
+                'per_page' => $roles->perPage(),
+                'current_page' => $roles->currentPage(),
+                'last_page' => $roles->lastPage(),
+            ],
+            'errors' => null,
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/admin/roles',
+        summary: 'Crear rol',
+        description: 'Crea un nuevo rol en el sistema.',
+        operationId: 'roleStore',
+        security: [['sanctum' => []]],
+        tags: ['Roles']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['name'],
+            properties: [
+                new OA\Property(property: 'name', type: 'string', example: 'editor'),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 201,
+        description: 'Rol creado correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Rol creado correctamente.'),
+                        new OA\Property(property: 'data', ref: '#/components/schemas/Role'),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Error de validación',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'Error de validación.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function store(CreateRoleRequest $request): JsonResponse
+    {
+        $role = Role::create([
+            'name' => $request->name,
+            'guard_name' => 'web',
+        ]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Rol creado correctamente.',
+            'data' => RoleResource::make($role),
+            'errors' => null,
+        ], 201);
+    }
+
+    #[OA\Get(
+        path: '/admin/roles/{id}',
+        summary: 'Obtener rol por ID',
+        description: 'Retorna un rol específico con sus permisos asociados.',
+        operationId: 'roleShow',
+        security: [['sanctum' => []]],
+        tags: ['Roles']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID del rol',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Rol obtenido correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Rol obtenido correctamente.'),
+                        new OA\Property(property: 'data', ref: '#/components/schemas/Role'),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Rol no encontrado',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'Rol no encontrado.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(
+                            property: 'errors',
+                            type: 'object',
+                            example: ['role' => ['No existe un rol con ese ID']]
+                        ),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function show(string $id): JsonResponse
+    {
+        $role = Role::with('permissions')->find($id);
+
+        if (! $role) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Rol no encontrado.',
+                'data' => null,
+                'errors' => ['role' => ['No existe un rol con ese ID']],
+            ], 404);
+        }
+
+        $modelHasRolesTable = config('permission.table_names.model_has_roles', 'model_has_roles');
+        $role->users_count = DB::table($modelHasRolesTable)
+            ->where('role_id', $role->id)
+            ->count();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Rol obtenido correctamente.',
+            'data' => RoleResource::make($role),
+            'errors' => null,
+        ]);
+    }
+
+    #[OA\Put(
+        path: '/admin/roles/{id}',
+        summary: 'Actualizar rol',
+        description: 'Actualiza un rol existente.',
+        operationId: 'roleUpdate',
+        security: [['sanctum' => []]],
+        tags: ['Roles']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID del rol',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'name', type: 'string', example: 'editor'),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Rol actualizado correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Rol actualizado correctamente.'),
+                        new OA\Property(property: 'data', ref: '#/components/schemas/Role'),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Rol no encontrado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Error de validación',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'Error de validación.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function update(UpdateRoleRequest $request, string $id): JsonResponse
+    {
+        $role = Role::find($id);
+
+        if (! $role) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Rol no encontrado.',
+                'data' => null,
+                'errors' => null,
+            ], 404);
+        }
+
+        $role->update($request->validated());
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Rol actualizado correctamente.',
+            'data' => RoleResource::make($role->load('permissions')),
+            'errors' => null,
+        ]);
+    }
+
+    #[OA\Delete(
+        path: '/admin/roles/{id}',
+        summary: 'Eliminar rol',
+        description: 'Elimina un rol por ID. No se puede eliminar si tiene usuarios asignados o si es SUPER_ADMIN.',
+        operationId: 'roleDestroy',
+        security: [['sanctum' => []]],
+        tags: ['Roles']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID del rol a eliminar',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Rol eliminado correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Rol eliminado correctamente.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Rol no encontrado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 409,
+        description: 'Conflicto - tiene usuarios asignados',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No se puede eliminar el rol porque tiene usuarios asignados.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'No se puede eliminar el rol protegido',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No se puede eliminar el rol SUPER_ADMIN.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function destroy(string $id): JsonResponse
+    {
+        $role = Role::find($id);
+
+        if (! $role) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Rol no encontrado.',
+                'data' => null,
+                'errors' => null,
+            ], 404);
+        }
+
+        if ($role->name === 'SUPER_ADMIN') {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se puede eliminar el rol SUPER_ADMIN.',
+                'data' => null,
+                'errors' => null,
+            ], 422);
+        }
+
+        if ($role->users()->exists()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se puede eliminar el rol porque tiene usuarios asignados.',
+                'data' => null,
+                'errors' => null,
+            ], 409);
+        }
+
+        $role->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Rol eliminado correctamente.',
+            'data' => null,
+            'errors' => null,
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/admin/roles/{id}/sync-permissions',
+        summary: 'Sincronizar permisos del rol',
+        description: 'Sincroniza los permisos asociados a un rol, reemplazando los existentes. Crea permisos faltantes automáticamente.',
+        operationId: 'roleSyncPermissions',
+        security: [['sanctum' => []]],
+        tags: ['Roles']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID del rol',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['permissions'],
+            properties: [
+                new OA\Property(
+                    property: 'permissions',
+                    type: 'array',
+                    items: new OA\Items(type: 'string'),
+                    example: ['stores.view', 'stores.create', 'stores.edit']
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Permisos sincronizados correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'success'),
+                        new OA\Property(property: 'message', example: 'Permisos sincronizados correctamente.'),
+                        new OA\Property(property: 'data', ref: '#/components/schemas/Role'),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Sin permisos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'No tenés permisos para realizar esta acción.'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Rol no encontrado',
+        content: new OA\JsonContent(ref: '#/components/schemas/ApiResponse')
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Error de validación',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', example: 'error'),
+                        new OA\Property(property: 'message', example: 'Error de validación.'),
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', type: 'object'),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function syncPermissions(SyncPermissionsRequest $request, string $id): JsonResponse
+    {
+        $role = Role::find($id);
+
+        if (! $role) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Rol no encontrado.',
+                'data' => null,
+                'errors' => null,
+            ], 404);
+        }
+
+        foreach ($request->permissions as $permissionName) {
+            Permission::firstOrCreate(
+                ['name' => $permissionName, 'guard_name' => 'web']
+            );
+        }
+
+        $role->syncPermissions($request->permissions);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Permisos sincronizados correctamente.',
+            'data' => RoleResource::make($role->load('permissions')),
+            'errors' => null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/V1/Admin/CreateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/Admin/CreateRoleRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class CreateRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'unique:roles,name'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'El nombre es obligatorio.',
+            'name.string' => 'El nombre debe ser un texto.',
+            'name.max' => 'El nombre no puede tener más de 255 caracteres.',
+            'name.unique' => 'Ya existe un rol con este nombre.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Requests/Api/V1/Admin/SyncPermissionsRequest.php
+++ b/app/Http/Requests/Api/V1/Admin/SyncPermissionsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class SyncPermissionsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'permissions' => ['required', 'array'],
+            'permissions.*' => ['string'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'permissions.required' => 'El array de permisos es obligatorio.',
+            'permissions.array' => 'El formato de permisos no es válido.',
+            'permissions.*.string' => 'Cada permiso debe ser un texto.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Requests/Api/V1/Admin/UpdateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/Admin/UpdateRoleRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rule;
+
+class UpdateRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255', Rule::unique('roles')->ignore($this->route('role'))],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.string' => 'El nombre debe ser un texto.',
+            'name.max' => 'El nombre no puede tener más de 255 caracteres.',
+            'name.unique' => 'Ya existe un rol con este nombre.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Resources/RoleResource.php
+++ b/app/Http/Resources/RoleResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class RoleResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'guard_name' => $this->guard_name,
+            'users_count' => $this->users_count ?? $this->whenCounted('users'),
+            'permissions_count' => $this->whenCounted('permissions'),
+            'permissions' => $this->permissions->pluck('name'),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/OpenApi/Schemas/Admin/RoleSchema.php
+++ b/app/OpenApi/Schemas/Admin/RoleSchema.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\OpenApi\Schemas\Admin;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: "Role",
+    title: "Rol",
+    description: "Rol del sistema"
+)]
+class RoleSchema
+{
+    #[OA\Property(example: 1)]
+    public int $id;
+
+    #[OA\Property(example: "STORE_ADMIN")]
+    public string $name;
+
+    #[OA\Property(example: "web")]
+    public string $guard_name;
+
+    #[OA\Property(type: "integer", example: 5)]
+    public int $users_count;
+
+    #[OA\Property(type: "integer", example: 8)]
+    public int $permissions_count;
+
+    #[OA\Property(type: "array", items: new OA\Items(type: "string"), example: ["stores.view", "stores.create"])]
+    public array $permissions;
+
+    #[OA\Property(example: "2026-04-27T22:00:06.000000Z")]
+    public string $created_at;
+
+    #[OA\Property(example: "2026-04-27T22:00:06.000000Z")]
+    public string $updated_at;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,7 +2,9 @@
 
 use App\Http\Controllers\Api\V1\Admin\BusinessTypeController;
 use App\Http\Controllers\Api\V1\Admin\FeatureController;
+use App\Http\Controllers\Api\V1\Admin\PermissionController;
 use App\Http\Controllers\Api\V1\Admin\PlanController;
+use App\Http\Controllers\Api\V1\Admin\RoleController;
 use App\Http\Controllers\Api\V1\Admin\StoreController;
 use App\Http\Controllers\Api\V1\Admin\UserController;
 use App\Http\Controllers\Api\V1\AuthController;
@@ -51,6 +53,10 @@ Route::prefix('v1')->group(function () {
             Route::middleware('role:SUPER_ADMIN')->group(function () {
                 Route::apiResource('plans', PlanController::class);
                 Route::post('plans/{plan}/sync-features', [PlanController::class, 'syncFeatures']);
+
+                Route::apiResource('roles', RoleController::class);
+                Route::post('roles/{role}/sync-permissions', [RoleController::class, 'syncPermissions']);
+                Route::get('permissions', [PermissionController::class, 'index']);
             });
 
             Route::middleware('role:SUPER_ADMIN|STORE_ADMIN')->group(function () {

--- a/tests/Feature/Api/V1/Admin/RoleTest.php
+++ b/tests/Feature/Api/V1/Admin/RoleTest.php
@@ -1,0 +1,542 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+  Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
+  Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+});
+
+function authHeaders(User $user): array
+{
+  $token = $user->createToken('test-token')->plainTextToken;
+
+  return ['Authorization' => "Bearer $token"];
+}
+
+// ============================================================
+// INDEX
+// ============================================================
+
+test('super admin can list all roles', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson('/api/v1/admin/roles');
+
+  $response->assertStatus(200)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Listado de roles obtenido correctamente.')
+    ->assertJsonCount(2, 'data.items')
+    ->assertJsonPath('data.total', 2)
+    ->assertJsonPath('data.per_page', 15)
+    ->assertJsonPath('data.current_page', 1);
+});
+
+test('index includes users_count and permissions_count', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+  $permission = Permission::create(['name' => 'stores.view', 'guard_name' => 'web']);
+  $role->givePermissionTo($permission);
+
+  $user1 = User::factory()->create();
+  $user1->assignRole('STORE_ADMIN');
+  $user2 = User::factory()->create();
+  $user2->assignRole('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson('/api/v1/admin/roles');
+
+  $storeAdminData = collect($response->json('data.items'))
+    ->firstWhere('name', 'STORE_ADMIN');
+
+  expect($storeAdminData['users_count'])->toBe(2);
+  expect($storeAdminData['permissions_count'])->toBe(1);
+});
+
+test('index includes permissions array', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+  Permission::create(['name' => 'stores.view', 'guard_name' => 'web']);
+  Permission::create(['name' => 'stores.create', 'guard_name' => 'web']);
+  $role->syncPermissions(['stores.view', 'stores.create']);
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson('/api/v1/admin/roles');
+
+  $storeAdminData = collect($response->json('data.items'))
+    ->firstWhere('name', 'STORE_ADMIN');
+
+  expect($storeAdminData['permissions'])->toBeArray();
+  expect($storeAdminData['permissions'])->toHaveCount(2);
+  expect($storeAdminData['permissions'])->toContain('stores.view');
+  expect($storeAdminData['permissions'])->toContain('stores.create');
+});
+
+test('index rejects unauthenticated request', function () {
+  /** @var \Tests\TestCase $this */
+  $response = $this->getJson('/api/v1/admin/roles');
+
+  $response->assertStatus(401);
+});
+
+test('index rejects non super admin role', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->getJson('/api/v1/admin/roles');
+
+  $response->assertStatus(403);
+});
+
+// ============================================================
+// STORE
+// ============================================================
+
+test('super admin can create a new role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson('/api/v1/admin/roles', ['name' => 'editor']);
+
+  $response->assertStatus(201)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Rol creado correctamente.')
+    ->assertJsonPath('data.name', 'editor')
+    ->assertJsonPath('data.guard_name', 'web');
+
+  $this->assertDatabaseHas('roles', ['name' => 'editor', 'guard_name' => 'web']);
+});
+
+test('store rejects duplicate role name', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson('/api/v1/admin/roles', ['name' => 'SUPER_ADMIN']);
+
+  $response->assertStatus(422)
+    ->assertJsonPath('status', 'error')
+    ->assertJsonPath('message', 'Error de validación.')
+    ->assertJsonPath('errors.name.0', 'Ya existe un rol con este nombre.');
+});
+
+test('store requires name field', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson('/api/v1/admin/roles', []);
+
+  $response->assertStatus(422)
+    ->assertJsonPath('message', 'Error de validación.')
+    ->assertJsonStructure(['errors' => ['name']]);
+});
+
+test('store rejects non super admin', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->postJson('/api/v1/admin/roles', ['name' => 'editor']);
+
+  $response->assertStatus(403);
+});
+
+// ============================================================
+// SHOW
+// ============================================================
+
+test('super admin can view a role with permissions', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+  Permission::create(['name' => 'stores.view', 'guard_name' => 'web']);
+  Permission::create(['name' => 'stores.create', 'guard_name' => 'web']);
+  $role->syncPermissions(['stores.view', 'stores.create']);
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson("/api/v1/admin/roles/{$role->id}");
+
+  $response->assertStatus(200)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Rol obtenido correctamente.')
+    ->assertJsonPath('data.id', $role->id)
+    ->assertJsonPath('data.name', 'STORE_ADMIN')
+    ->assertJsonCount(2, 'data.permissions')
+    ->assertJsonPath('data.users_count', 0);
+});
+
+test('show returns 404 for non-existent role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson('/api/v1/admin/roles/9999');
+
+  $response->assertStatus(404)
+    ->assertJsonPath('message', 'Rol no encontrado.');
+});
+
+test('show rejects non super admin', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $role = Role::findByName('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->getJson("/api/v1/admin/roles/{$role->id}");
+
+  $response->assertStatus(403);
+});
+
+// ============================================================
+// UPDATE
+// ============================================================
+
+test('super admin can update a role name', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  Role::create(['name' => 'editor', 'guard_name' => 'web']);
+  $role = Role::findByName('editor');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->putJson("/api/v1/admin/roles/{$role->id}", ['name' => 'moderator']);
+
+  $response->assertStatus(200)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Rol actualizado correctamente.')
+    ->assertJsonPath('data.name', 'moderator');
+
+  $this->assertDatabaseHas('roles', ['id' => $role->id, 'name' => 'moderator']);
+  $this->assertDatabaseMissing('roles', ['name' => 'editor']);
+});
+
+test('update rejects duplicate name', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  Role::create(['name' => 'editor', 'guard_name' => 'web']);
+  $role = Role::findByName('editor');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->putJson("/api/v1/admin/roles/{$role->id}", ['name' => 'SUPER_ADMIN']);
+
+  $response->assertStatus(422)
+    ->assertJsonPath('errors.name.0', 'Ya existe un rol con este nombre.');
+});
+
+test('update returns 404 for non-existent role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->putJson('/api/v1/admin/roles/9999', ['name' => 'test']);
+
+  $response->assertStatus(404)
+    ->assertJsonPath('message', 'Rol no encontrado.');
+});
+
+test('update rejects non super admin', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->putJson("/api/v1/admin/roles/{$role->id}", ['name' => 'renamed']);
+
+  $response->assertStatus(403);
+});
+
+// ============================================================
+// DESTROY
+// ============================================================
+
+test('super admin can delete a role without users', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  Role::create(['name' => 'temp_role', 'guard_name' => 'web']);
+  $role = Role::findByName('temp_role');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->deleteJson("/api/v1/admin/roles/{$role->id}");
+
+  $response->assertStatus(200)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Rol eliminado correctamente.');
+
+  $this->assertDatabaseMissing('roles', ['name' => 'temp_role']);
+});
+
+test('destroy rejects deleting SUPER_ADMIN role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->deleteJson("/api/v1/admin/roles/{$role->id}");
+
+  $response->assertStatus(422)
+    ->assertJsonPath('message', 'No se puede eliminar el rol SUPER_ADMIN.');
+
+  $this->assertDatabaseHas('roles', ['name' => 'SUPER_ADMIN']);
+});
+
+test('destroy rejects deleting role with assigned users', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->deleteJson("/api/v1/admin/roles/{$role->id}");
+
+  $response->assertStatus(409)
+    ->assertJsonPath('message', 'No se puede eliminar el rol porque tiene usuarios asignados.');
+
+  $this->assertDatabaseHas('roles', ['name' => 'STORE_ADMIN']);
+});
+
+test('destroy returns 404 for non-existent role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->deleteJson('/api/v1/admin/roles/9999');
+
+  $response->assertStatus(404)
+    ->assertJsonPath('message', 'Rol no encontrado.');
+});
+
+test('destroy rejects non super admin', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->deleteJson("/api/v1/admin/roles/{$role->id}");
+
+  $response->assertStatus(403);
+});
+
+// ============================================================
+// SYNC PERMISSIONS
+// ============================================================
+
+test('super admin can sync permissions to a role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson("/api/v1/admin/roles/{$role->id}/sync-permissions", [
+      'permissions' => ['stores.view', 'stores.create'],
+    ]);
+
+  $response->assertStatus(200)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Permisos sincronizados correctamente.')
+    ->assertJsonCount(2, 'data.permissions')
+    ->assertJsonPath('data.permissions', ['stores.view', 'stores.create']);
+
+  expect($role->fresh()->permissions->pluck('name')->toArray())->toBe(['stores.view', 'stores.create']);
+});
+
+test('sync permissions replaces existing permissions', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+  Permission::create(['name' => 'stores.view', 'guard_name' => 'web']);
+  Permission::create(['name' => 'stores.delete', 'guard_name' => 'web']);
+  $role->syncPermissions(['stores.view', 'stores.delete']);
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson("/api/v1/admin/roles/{$role->id}/sync-permissions", [
+      'permissions' => ['stores.create', 'stores.edit'],
+    ]);
+
+  $response->assertStatus(200);
+
+  $permissions = $role->fresh()->permissions->pluck('name')->toArray();
+  expect($permissions)->toBe(['stores.create', 'stores.edit']);
+  expect($permissions)->not->toContain('stores.view');
+  expect($permissions)->not->toContain('stores.delete');
+});
+
+test('sync permissions creates missing permissions automatically', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson("/api/v1/admin/roles/{$role->id}/sync-permissions", [
+      'permissions' => ['brand.new.permission'],
+    ]);
+
+  $response->assertStatus(200);
+
+  $this->assertDatabaseHas('permissions', ['name' => 'brand.new.permission', 'guard_name' => 'web']);
+  expect($role->fresh()->permissions->pluck('name')->toArray())->toBe(['brand.new.permission']);
+});
+
+test('sync permissions rejects empty array', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+  Permission::create(['name' => 'stores.view', 'guard_name' => 'web']);
+  $role->givePermissionTo('stores.view');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson("/api/v1/admin/roles/{$role->id}/sync-permissions", [
+      'permissions' => [],
+    ]);
+
+  $response->assertStatus(422)
+    ->assertJsonPath('errors.permissions.0', 'El array de permisos es obligatorio.');
+});
+
+test('sync permissions returns 404 for non-existent role', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson('/api/v1/admin/roles/9999/sync-permissions', [
+      'permissions' => ['stores.view'],
+    ]);
+
+  $response->assertStatus(404)
+    ->assertJsonPath('message', 'Rol no encontrado.');
+});
+
+test('sync permissions requires permissions field', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->postJson("/api/v1/admin/roles/{$role->id}/sync-permissions", []);
+
+  $response->assertStatus(422)
+    ->assertJsonPath('message', 'Error de validación.')
+    ->assertJsonStructure(['errors' => ['permissions']]);
+});
+
+test('sync permissions rejects non super admin', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $role = Role::findByName('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->postJson("/api/v1/admin/roles/{$role->id}/sync-permissions", [
+      'permissions' => ['stores.view'],
+    ]);
+
+  $response->assertStatus(403);
+});
+
+// ============================================================
+// PERMISSIONS INDEX
+// ============================================================
+
+test('super admin can list all permissions grouped by resource', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  Permission::create(['name' => 'stores.view', 'guard_name' => 'web']);
+  Permission::create(['name' => 'stores.create', 'guard_name' => 'web']);
+  Permission::create(['name' => 'users.view', 'guard_name' => 'web']);
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson('/api/v1/admin/permissions');
+
+  $response->assertStatus(200)
+    ->assertJsonPath('status', 'success')
+    ->assertJsonPath('message', 'Listado de permisos obtenido correctamente.')
+    ->assertJsonPath('data.stores', ['stores.view', 'stores.create'])
+    ->assertJsonPath('data.users', ['users.view']);
+});
+
+test('permissions index returns empty object when no permissions exist', function () {
+  /** @var \Tests\TestCase $this */
+  $admin = User::factory()->create();
+  $admin->assignRole('SUPER_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($admin))
+    ->getJson('/api/v1/admin/permissions');
+
+  $response->assertStatus(200)
+    ->assertJsonPath('data', []);
+});
+
+test('permissions index rejects unauthenticated request', function () {
+  /** @var \Tests\TestCase $this */
+  $response = $this->getJson('/api/v1/admin/permissions');
+
+  $response->assertStatus(401);
+});
+
+test('permissions index rejects non super admin', function () {
+  /** @var \Tests\TestCase $this */
+  $user = User::factory()->create();
+  $user->assignRole('STORE_ADMIN');
+
+  $response = $this->withHeaders(authHeaders($user))
+    ->getJson('/api/v1/admin/permissions');
+
+  $response->assertStatus(403);
+});


### PR DESCRIPTION
- RoleController: index, store, show, update, destroy, syncPermissions
- PermissionController: list permissions grouped by resource
- FormRequests: CreateRoleRequest, UpdateRoleRequest, SyncPermissionsRequest
- RoleResource with users_count, permissions_count and permissions array
- RoleSchema for OpenAPI documentation
- RoleTest with 32 tests covering all endpoints and edge cases
- Routes under auth:sanctum + role:SUPER_ADMIN middleware