### PR TITLE
Refactor AuthTest to include user activation status and improve login validation

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/UserController.php
+++ b/app/Http/Controllers/Api/V1/Admin/UserController.php
@@ -138,6 +138,7 @@ class UserController extends Controller
     #[OA\Parameter(name: 'name', in: 'query', required: false, description: 'Filtrar por nombre', schema: new OA\Schema(type: 'string', example: 'Juan'))]
     #[OA\Parameter(name: 'role', in: 'query', required: false, description: 'Filtrar por nombre de rol', schema: new OA\Schema(type: 'string', example: 'ADMIN'))]
     #[OA\Parameter(name: 'store_id', in: 'query', required: false, description: 'Filtrar por store_id (solo SUPER_ADMIN)', schema: new OA\Schema(type: 'string', example: '019dd4bc-7318-7094-829b-a02485ba6caf'))]
+    #[OA\Parameter(name: 'is_active', in: 'query', required: false, description: 'Filtrar por estado', schema: new OA\Schema(type: 'boolean', example: true))]
     #[OA\Parameter(name: 'per_page', in: 'query', required: false, description: 'Resultados por página (default: 15)', schema: new OA\Schema(type: 'integer', example: 15))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, description: 'Número de página', schema: new OA\Schema(type: 'integer', example: 1))]
 
@@ -226,6 +227,10 @@ class UserController extends Controller
             $q->where('store_id', $request->store_id);
         });
 
+        $query->when($request->has('is_active'), function ($q) use ($request) {
+            $q->where('is_active', $request->boolean('is_active'));
+        });
+
         $perPage = $request->integer('per_page', 15);
         $users = $query->paginate($perPage);
 
@@ -263,6 +268,7 @@ class UserController extends Controller
                 new OA\Property(property: 'password_confirmation', type: 'string', example: 'Password1'),
                 new OA\Property(property: 'role', type: 'string', example: 'STORE_ADMIN'),
                 new OA\Property(property: 'store_id', type: 'string', nullable: true, example: '019dd4bc-7318-7094-829b-a02485ba6caf'),
+                new OA\Property(property: 'is_active', type: 'boolean', description: 'Estado del usuario. Por defecto es true.', example: true),
             ]
         )
     )]
@@ -365,12 +371,18 @@ class UserController extends Controller
         try {
             return DB::transaction(function () use ($request, $storeId) {
 
-                $user = User::create([
+                $userData = [
                     'name' => $request->name,
                     'email' => $request->email,
                     'password' => $request->password,
                     'store_id' => $storeId,
-                ]);
+                ];
+
+                if ($request->has('is_active')) {
+                    $userData['is_active'] = $request->boolean('is_active');
+                }
+
+                $user = User::create($userData);
 
                 $user->assignRole($request->role);
 
@@ -514,7 +526,7 @@ class UserController extends Controller
     #[OA\Put(
         path: '/admin/users/{id}',
         summary: 'Actualizar usuario',
-        description: 'Actualiza los datos de un usuario. El password y el store_id son opcionales. STORE_ADMIN solo puede editar usuarios de su tienda y no puede asignar el rol SUPER_ADMIN.',
+        description: 'Actualiza los datos de un usuario. El password, store_id e is_active son opcionales. STORE_ADMIN solo puede editar usuarios de su tienda y no puede asignar el rol SUPER_ADMIN.',
         operationId: 'userUpdate',
         security: [['sanctum' => []]],
         tags: ['Users']
@@ -536,6 +548,7 @@ class UserController extends Controller
                 new OA\Property(property: 'password_confirmation', type: 'string', example: 'NewPassword123'),
                 new OA\Property(property: 'role', type: 'string', example: 'STORE_ADMIN'),
                 new OA\Property(property: 'store_id', type: 'string', nullable: true, description: 'Solo editable por SUPER_ADMIN', example: '019dd4bc-7318-7094-829b-a02485ba6caf'),
+                new OA\Property(property: 'is_active', type: 'boolean', description: 'Estado del usuario', example: true),
             ]
         )
     )]
@@ -682,6 +695,10 @@ class UserController extends Controller
 
                 if ($authUser->hasRole('SUPER_ADMIN') && $request->has('store_id')) {
                     $user->store_id = $request->store_id;
+                }
+
+                if ($request->has('is_active')) {
+                    $user->is_active = $request->boolean('is_active');
                 }
 
                 $user->save();

--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -14,276 +14,310 @@ use OpenApi\Attributes as OA;
 
 class AuthController extends Controller
 {
-  #[OA\Post(
-    path: "/login",
-    summary: "Inicio de sesión",
-    description: "Autentica al usuario y devuelve un token de acceso (Sanctum).",
-    operationId: "authLogin",
-    tags: ["Autenticación"]
-  )]
-  #[OA\RequestBody(
-    required: true,
-    content: new OA\JsonContent(
-      required: ["email", "password"],
-      properties: [
-        new OA\Property(property: "email", type: "string", format: "email", example: "admin@centra.com"),
-        new OA\Property(property: "password", type: "string", format: "password", example: "password123")
-      ]
-    )
-  )]
-  #[OA\Response(
-    response: 200,
-    description: "Login exitoso",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(
-              property: "data",
-              type: "object",
-              properties: [
-                new OA\Property(property: "token", type: "string", example: "1|abc123token..."),
-                new OA\Property(property: "user", ref: "#/components/schemas/User"),
-              ]
-            ),
-            new OA\Property(property: "errors", type: "string", nullable: true, example: null),
-          ]
-        ),
-      ]
-    )
-  )]
-  #[OA\Response(
-    response: 401,
-    description: "Credenciales incorrectas",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(property: "status", type: "string", example: "error"),
-            new OA\Property(property: "message", type: "string", example: "Credenciales incorrectas"),
-            new OA\Property(
-              property: "errors",
-              type: "object",
-              example: [
-                "auth" => [
-                  "El email o la contraseña no coinciden con nuestros registros."
-                ]
-              ]
-            )
-          ]
+    #[OA\Post(
+        path: '/login',
+        summary: 'Inicio de sesión',
+        description: 'Autentica al usuario y devuelve un token de acceso (Sanctum).',
+        operationId: 'authLogin',
+        tags: ['Autenticación']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['email', 'password'],
+            properties: [
+                new OA\Property(property: 'email', type: 'string', format: 'email', example: 'admin@centra.com'),
+                new OA\Property(property: 'password', type: 'string', format: 'password', example: 'password123'),
+            ]
         )
-      ]
-    )
-  )]
-  #[OA\Response(
-    response: 422,
-    description: "Error de validación de campos",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(property: "status", type: "string", example: "error"),
-            new OA\Property(property: "message", type: "string", example: "Datos de entrada inválidos"),
-            new OA\Property(
-              property: "errors",
-              type: "object",
-              example: [
-                "email" => ["The email field must be a valid email address."],
-                "password" => ["The password field is required."]
-              ]
-            )
-          ]
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Login exitoso',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OA\Property(property: 'token', type: 'string', example: '1|abc123token...'),
+                                new OA\Property(property: 'user', ref: '#/components/schemas/User'),
+                            ]
+                        ),
+                        new OA\Property(property: 'errors', type: 'string', nullable: true, example: null),
+                    ]
+                ),
+            ]
         )
-      ]
-    )
-  )]
-  public function login(LoginRequest $request): JsonResponse
-  {
-    $user = User::with('store.businessType', 'store.plan.features')
-      ->where('email', $request->email)
-      ->first();
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Credenciales incorrectas',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'string', example: 'error'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Credenciales incorrectas'),
+                        new OA\Property(
+                            property: 'errors',
+                            type: 'object',
+                            example: [
+                                'auth' => [
+                                    'El email o la contraseña no coinciden con nuestros registros.',
+                                ],
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Usuario inactivo',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'string', example: 'error'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Tu cuenta está desactivada.'),
+                        new OA\Property(
+                            property: 'errors',
+                            type: 'object',
+                            example: [
+                                'auth' => [
+                                    'Tu cuenta está desactivada. Contactá al administrador de la tienda.',
+                                ],
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Error de validación de campos',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'string', example: 'error'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Datos de entrada inválidos'),
+                        new OA\Property(
+                            property: 'errors',
+                            type: 'object',
+                            example: [
+                                'email' => ['The email field must be a valid email address.'],
+                                'password' => ['The password field is required.'],
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        )
+    )]
+    public function login(LoginRequest $request): JsonResponse
+    {
+        $user = User::with('store.businessType', 'store.plan.features')
+            ->where('email', $request->email)
+            ->first();
 
-    if (! $user || ! Hash::check($request->password, $user->password)) {
-      return response()->json([
-        'status'  => 'error',
-        'message' => 'Credenciales inválidas.',
-        'data'    => null,
-        'errors'  => ['auth' => ['El email o la contraseña son incorrectos.']],
-      ], 401);
+        if (! $user || ! Hash::check($request->password, $user->password)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Credenciales inválidas.',
+                'data' => null,
+                'errors' => ['auth' => ['El email o la contraseña son incorrectos.']],
+            ], 401);
+        }
+
+        if (! $user->is_active) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Tu cuenta está desactivada.',
+                'data' => null,
+                'errors' => ['auth' => ['Tu cuenta está desactivada. Contactá al administrador de la tienda.']],
+            ], 403);
+        }
+
+        $user->tokens()->delete();
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Autenticación exitosa.',
+            'data' => [
+                'token' => $token,
+                'user' => $this->formatUser($user),
+            ],
+            'errors' => null,
+        ], 200);
     }
 
-    $user->tokens()->delete();
-
-    $token = $user->createToken('api-token')->plainTextToken;
-
-    return response()->json([
-      'status'  => 'success',
-      'message' => 'Autenticación exitosa.',
-      'data'    => [
-        'token' => $token,
-        'user'  => $this->formatUser($user),
-      ],
-      'errors'  => null,
-    ], 200);
-  }
-
-  #[OA\Post(
-    path: "/logout",
-    summary: "Cerrar sesión",
-    description: "Revoca todos los tokens del usuario autenticado.",
-    operationId: "authLogout",
-    security: [['sanctum' => []]],
-    tags: ["Autenticación"]
-  )]
-  #[OA\Response(
-    response: 200,
-    description: "Sesión cerrada correctamente",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(property: "data", nullable: true, example: null),
-            new OA\Property(property: "errors", nullable: true, example: null)
-          ]
+    #[OA\Post(
+        path: '/logout',
+        summary: 'Cerrar sesión',
+        description: 'Revoca todos los tokens del usuario autenticado.',
+        operationId: 'authLogout',
+        security: [['sanctum' => []]],
+        tags: ['Autenticación']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Sesión cerrada correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'data', nullable: true, example: null),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                    ]
+                ),
+            ]
         )
-      ]
-    )
-  )]
-  #[OA\Response(
-    response: 401,
-    description: "No autenticado (token inválido o ausente)",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(property: "status", type: "string", example: "error"),
-            new OA\Property(property: "message", type: "string", example: "Unauthenticated."),
-            new OA\Property(
-              property: "errors",
-              type: "object",
-              example: [
-                "auth" => [
-                  "No autenticado."
-                ]
-              ]
-            )
-          ]
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado (token inválido o ausente)',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'string', example: 'error'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Unauthenticated.'),
+                        new OA\Property(
+                            property: 'errors',
+                            type: 'object',
+                            example: [
+                                'auth' => [
+                                    'No autenticado.',
+                                ],
+                            ]
+                        ),
+                    ]
+                ),
+            ]
         )
-      ]
-    )
-  )]
-  public function logout(Request $request): JsonResponse
-  {
-    $request->user()->tokens()->delete();
+    )]
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->tokens()->delete();
 
-    Auth::guard('web')->logout();
+        Auth::guard('web')->logout();
 
-    if ($request->hasSession()) {
-      $request->session()->invalidate();
-      $request->session()->regenerateToken();
+        if ($request->hasSession()) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Sesión cerrada correctamente.',
+            'data' => null,
+            'errors' => null,
+        ], 200);
     }
 
-    return response()->json([
-      'status'  => 'success',
-      'message' => 'Sesión cerrada correctamente.',
-      'data'    => null,
-      'errors'  => null,
-    ], 200);
-  }
-
-  #[OA\Get(
-    path: "/me",
-    summary: "Obtener usuario autenticado",
-    description: "Retorna los datos del usuario que tiene la sesión activa.",
-    operationId: "authMe",
-    security: [['sanctum' => []]],
-    tags: ["Autenticación"]
-  )]
-  #[OA\Response(
-    response: 200,
-    description: "Usuario obtenido correctamente",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(
-              property: "data",
-              type: "object",
-              properties: [
-                new OA\Property(property: "user", ref: "#/components/schemas/User")
-              ]
-            ),
-            new OA\Property(property: "errors", nullable: true, example: null),
-            new OA\Property(property: "message", example: 'Usuario autenticado.')
-          ]
+    #[OA\Get(
+        path: '/me',
+        summary: 'Obtener usuario autenticado',
+        description: 'Retorna los datos del usuario que tiene la sesión activa.',
+        operationId: 'authMe',
+        security: [['sanctum' => []]],
+        tags: ['Autenticación']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Usuario obtenido correctamente',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OA\Property(property: 'user', ref: '#/components/schemas/User'),
+                            ]
+                        ),
+                        new OA\Property(property: 'errors', nullable: true, example: null),
+                        new OA\Property(property: 'message', example: 'Usuario autenticado.'),
+                    ]
+                ),
+            ]
         )
-      ]
-    )
-  )]
-  #[OA\Response(
-    response: 401,
-    description: "No autenticado (token inválido o ausente)",
-    content: new OA\JsonContent(
-      allOf: [
-        new OA\Schema(ref: "#/components/schemas/ApiResponse"),
-        new OA\Schema(
-          properties: [
-            new OA\Property(property: "status", type: "string", example: "error"),
-            new OA\Property(property: "message", type: "string", example: "No autenticado."),
-            new OA\Property(
-              property: "errors",
-              type: "object",
-              example: [
-                "auth" => [
-                  "No autenticado."
-                ]
-              ]
-            )
-          ]
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'No autenticado (token inválido o ausente)',
+        content: new OA\JsonContent(
+            allOf: [
+                new OA\Schema(ref: '#/components/schemas/ApiResponse'),
+                new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'string', example: 'error'),
+                        new OA\Property(property: 'message', type: 'string', example: 'No autenticado.'),
+                        new OA\Property(
+                            property: 'errors',
+                            type: 'object',
+                            example: [
+                                'auth' => [
+                                    'No autenticado.',
+                                ],
+                            ]
+                        ),
+                    ]
+                ),
+            ]
         )
-      ]
-    )
-  )]
-  public function me(Request $request): JsonResponse
-  {
-    $user = $request->user()->load(['roles', 'store.businessType', 'store.plan.features']);
+    )]
+    public function me(Request $request): JsonResponse
+    {
+        $user = $request->user()->load(['roles', 'store.businessType', 'store.plan.features']);
 
-    return response()->json([
-      'status'  => 'success',
-      'message' => 'Usuario autenticado.',
-      'data'    => [
-        'user' => $this->formatUser($user),
-      ],
-      'errors'  => null,
-    ], 200);
-  }
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Usuario autenticado.',
+            'data' => [
+                'user' => $this->formatUser($user),
+            ],
+            'errors' => null,
+        ], 200);
+    }
 
-  /**
-   * Format User for standard response.
-   */
-  private function formatUser(User $user): array
-  {
-    $features = $user->store?->plan?->features->map(fn($f) => [
-      'code'  => $f->code,
-      'limit' => $f->pivot->limit_value,
-    ])->toArray() ?? [];
+    /**
+     * Format User for standard response.
+     */
+    private function formatUser(User $user): array
+    {
+        $features = $user->store?->plan?->features->map(fn ($f) => [
+            'code' => $f->code,
+            'limit' => $f->pivot->limit_value,
+        ])->toArray() ?? [];
 
-    return [
-      'id'          => $user->id,
-      'name'        => $user->name,
-      'email'       => $user->email,
-      'store'       => $user->store
-        ? (new SimpleStoreResource($user->store))->toArray(request())
-        : null,
-      'roles'       => $user->getRoleNames()->toArray(),
-      'permissions' => $user->getPermissionsViaRoles()->pluck('name')->toArray(),
-      'features'    => $features,
-    ];
-  }
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'is_active' => $user->is_active,
+            'store' => $user->store
+              ? (new SimpleStoreResource($user->store))->toArray(request())
+              : null,
+            'roles' => $user->getRoleNames()->toArray(),
+            'permissions' => $user->getPermissionsViaRoles()->pluck('name')->toArray(),
+            'features' => $features,
+        ];
+    }
 }

--- a/app/Http/Requests/Api/V1/Admin/UpdateUserRequest.php
+++ b/app/Http/Requests/Api/V1/Admin/UpdateUserRequest.php
@@ -2,65 +2,67 @@
 
 namespace App\Http\Requests\Api\V1\Admin;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Rule;
 
 class UpdateUserRequest extends FormRequest
 {
-  public function authorize(): bool
-  {
-    return true;
-  }
+    public function authorize(): bool
+    {
+        return true;
+    }
 
-  public function rules(): array
-  {
-    $userId = $this->route('user');
+    public function rules(): array
+    {
+        $userId = $this->route('user');
 
-    return [
-      'name'  => ['sometimes', 'string', 'max:255'],
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
 
-      'email' => [
-        'sometimes',
-        'string',
-        'email',
-        'max:255',
-        Rule::unique('users', 'email')->ignore($userId),
-      ],
+            'email' => [
+                'sometimes',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->ignore($userId),
+            ],
 
-      'password' => ['sometimes', 'string', 'confirmed', 'min:6'],
+            'password' => ['sometimes', 'string', 'confirmed', 'min:6'],
 
-      'role' => ['sometimes', 'string', 'exists:roles,name'],
+            'role' => ['sometimes', 'string', 'exists:roles,name'],
 
-      'store_id' => ['sometimes', 'nullable', 'uuid', 'exists:stores,id'],
-    ];
-  }
+            'store_id' => ['sometimes', 'nullable', 'uuid', 'exists:stores,id'],
 
-  public function messages(): array
-  {
-    return [
+            'is_active' => ['sometimes', 'boolean'],
+        ];
+    }
 
-      'email.email'    => 'El email debe tener un formato válido.',
-      'email.unique'   => 'Ya existe un usuario con este email.',
+    public function messages(): array
+    {
+        return [
 
-      'password.confirmed' => 'Las contraseñas no coinciden.',
-      'password.min'       => 'La contraseña debe tener al menos 6 caracteres.',
+            'email.email' => 'El email debe tener un formato válido.',
+            'email.unique' => 'Ya existe un usuario con este email.',
 
-      'store_id.uuid'   => 'El store_id debe ser un UUID válido.',
-      'store_id.exists' => 'La tienda seleccionada no existe.',
-    ];
-  }
+            'password.confirmed' => 'Las contraseñas no coinciden.',
+            'password.min' => 'La contraseña debe tener al menos 6 caracteres.',
 
-  protected function failedValidation(Validator $validator): void
-  {
-    throw new HttpResponseException(
-      response()->json([
-        'status'  => 'error',
-        'message' => 'Error de validación.',
-        'data'    => null,
-        'errors'  => $validator->errors(),
-      ], 422)
-    );
-  }
+            'store_id.uuid' => 'El store_id debe ser un UUID válido.',
+            'store_id.exists' => 'La tienda seleccionada no existe.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -7,18 +7,19 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class UserResource extends JsonResource
 {
-  public function toArray(Request $request): array
-  {
-    return [
-      'id'          => $this->id,
-      'name'        => $this->name,
-      'email'       => $this->email,
-      'store'    => new SimpleStoreResource($this->whenLoaded('store')),
-      'roles'       => $this->getRoleNames()->toArray(),
-      'permissions' => $this->getPermissionsViaRoles()->pluck('name')->toArray(),
-      'features'    => $this->whenLoaded('store', function () {
-        return $this->store?->plan?->features->pluck('code')->toArray() ?? [];
-      }, []),
-    ];
-  }
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'is_active' => $this->is_active,
+            'store' => new SimpleStoreResource($this->whenLoaded('store')),
+            'roles' => $this->getRoleNames()->toArray(),
+            'permissions' => $this->getPermissionsViaRoles()->pluck('name')->toArray(),
+            'features' => $this->whenLoaded('store', function () {
+                return $this->store?->plan?->features->pluck('code')->toArray() ?? [];
+            }, []),
+        ];
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,55 +2,60 @@
 
 namespace App\Models;
 
-use App\Models\Store;
-use Laravel\Sanctum\HasApiTokens;
-use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
+use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-  use HasApiTokens, HasFactory, Notifiable, HasRoles;
+    use HasApiTokens, HasFactory, HasRoles, Notifiable;
 
-  protected $keyType = 'string';
-  public $incrementing = false;
+    protected $keyType = 'string';
 
+    public $incrementing = false;
 
-  protected $fillable = [
-    'name',
-    'email',
-    'password',
-    'store_id',
-  ];
-
-  protected $hidden = [
-    'password',
-    'remember_token',
-  ];
-
-  protected function casts(): array
-  {
-    return [
-      'email_verified_at' => 'datetime',
-      'password' => 'hashed',
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'is_active',
+        'store_id',
     ];
-  }
 
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
 
-  protected static function booted()
-  {
-    static::creating(function ($model) {
-      if (! $model->id) {
-        $model->id = (string) Str::uuid();
-      }
-    });
-  }
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+            'is_active' => 'boolean',
+        ];
+    }
 
-  public function store(): BelongsTo
-  {
-    return $this->belongsTo(Store::class);
-  }
+    protected static function booted()
+    {
+        static::creating(function ($model) {
+            if (! $model->id) {
+                $model->id = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
 }

--- a/app/OpenApi/Schemas/UserSchema.php
+++ b/app/OpenApi/Schemas/UserSchema.php
@@ -5,56 +5,58 @@ namespace App\OpenApi\Schemas;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(
-  schema: "User",
-  title: "User",
-  description: "Modelo de usuario de CENTRA",
-  type: "object"
+    schema: 'User',
+    title: 'User',
+    description: 'Modelo de usuario de CENTRA',
+    type: 'object'
 )]
 class UserSchema
 {
-  #[OA\Property(property: "id", type: "string", example: "123e4567-e89b-12d3-a456-426614174000")]
-  public int $id;
+    #[OA\Property(property: 'id', type: 'string', example: '123e4567-e89b-12d3-a456-426614174000')]
+    public int $id;
 
-  #[OA\Property(property: "name", type: "string", example: "Admin Centra")]
-  public string $name;
+    #[OA\Property(property: 'name', type: 'string', example: 'Admin Centra')]
+    public string $name;
 
-  #[OA\Property(property: "email", type: "string", format: "email", example: "admin@centra.com")]
-  public string $email;
+    #[OA\Property(property: 'email', type: 'string', format: 'email', example: 'admin@centra.com')]
+    public string $email;
 
-  #[OA\Property(
-    property: "store",
-    ref: "#/components/schemas/StoreLight"
-  )]
+    #[OA\Property(property: 'is_active', type: 'boolean', example: true)]
+    public bool $is_active;
 
-  public $store;
+    #[OA\Property(
+        property: 'store',
+        ref: '#/components/schemas/StoreLight'
+    )]
+    public $store;
 
-  #[OA\Property(
-    property: "roles",
-    type: "array",
-    items: new OA\Items(type: "string"),
-    example: ["admin"]
-  )]
-  public array $roles;
+    #[OA\Property(
+        property: 'roles',
+        type: 'array',
+        items: new OA\Items(type: 'string'),
+        example: ['admin']
+    )]
+    public array $roles;
 
-  #[OA\Property(
-    property: "permissions",
-    type: "array",
-    items: new OA\Items(type: "string"),
-    example: ["cash.view"]
-  )]
-  public array $permissions;
+    #[OA\Property(
+        property: 'permissions',
+        type: 'array',
+        items: new OA\Items(type: 'string'),
+        example: ['cash.view']
+    )]
+    public array $permissions;
 
-  #[OA\Property(
-    property: "features",
-    type: "array",
-    items: new OA\Items(
-      type: "object",
-      properties: [
-        new OA\Property(property: "code", type: "string", example: "pos"),
-        new OA\Property(property: "limit", type: "integer", nullable: true, example: null),
-      ]
-    ),
-    example: [["code" => "pos", "limit" => null], ["code" => "multi_user", "limit" => 2]]
-  )]
-  public array $features;
+    #[OA\Property(
+        property: 'features',
+        type: 'array',
+        items: new OA\Items(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'code', type: 'string', example: 'pos'),
+                new OA\Property(property: 'limit', type: 'integer', nullable: true, example: null),
+            ]
+        ),
+        example: [['code' => 'pos', 'limit' => null], ['code' => 'multi_user', 'limit' => 2]]
+    )]
+    public array $features;
 }

--- a/database/migrations/2026_06_26_000000_add_is_active_to_users_table.php
+++ b/database/migrations/2026_06_26_000000_add_is_active_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('password');
+            $table->index('is_active');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['is_active']);
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -5097,6 +5097,16 @@
                         }
                     },
                     {
+                        "name": "is_active",
+                        "in": "query",
+                        "description": "Filtrar por estado",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "example": true
+                        }
+                    },
+                    {
                         "name": "per_page",
                         "in": "query",
                         "description": "Resultados por página (default: 15)",
@@ -5295,6 +5305,11 @@
                                         "type": "string",
                                         "example": "019dd4bc-7318-7094-829b-a02485ba6caf",
                                         "nullable": true
+                                    },
+                                    "is_active": {
+                                        "description": "Estado del usuario. Por defecto es true.",
+                                        "type": "boolean",
+                                        "example": true
                                     }
                                 },
                                 "type": "object"
@@ -5583,7 +5598,7 @@
                     "Users"
                 ],
                 "summary": "Actualizar usuario",
-                "description": "Actualiza los datos de un usuario. El password y el store_id son opcionales. STORE_ADMIN solo puede editar usuarios de su tienda y no puede asignar el rol SUPER_ADMIN.",
+                "description": "Actualiza los datos de un usuario. El password, store_id e is_active son opcionales. STORE_ADMIN solo puede editar usuarios de su tienda y no puede asignar el rol SUPER_ADMIN.",
                 "operationId": "userUpdate",
                 "parameters": [
                     {
@@ -5628,6 +5643,11 @@
                                         "type": "string",
                                         "example": "019dd4bc-7318-7094-829b-a02485ba6caf",
                                         "nullable": true
+                                    },
+                                    "is_active": {
+                                        "description": "Estado del usuario",
+                                        "type": "boolean",
+                                        "example": true
                                     }
                                 },
                                 "type": "object"
@@ -6057,6 +6077,41 @@
                                                     "example": {
                                                         "auth": [
                                                             "El email o la contraseña no coinciden con nuestros registros."
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Usuario inactivo",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ApiResponse"
+                                        },
+                                        {
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "error"
+                                                },
+                                                "message": {
+                                                    "type": "string",
+                                                    "example": "Tu cuenta está desactivada."
+                                                },
+                                                "errors": {
+                                                    "type": "object",
+                                                    "example": {
+                                                        "auth": [
+                                                            "Tu cuenta está desactivada. Contactá al administrador de la tienda."
                                                         ]
                                                     }
                                                 }
@@ -8174,6 +8229,10 @@
                         "type": "string",
                         "format": "email",
                         "example": "admin@centra.com"
+                    },
+                    "is_active": {
+                        "type": "boolean",
+                        "example": true
                     },
                     "store": {
                         "$ref": "#/components/schemas/StoreLight"

--- a/tests/Feature/Api/V1/Admin/UserTest.php
+++ b/tests/Feature/Api/V1/Admin/UserTest.php
@@ -10,8 +10,8 @@ use Spatie\Permission\Models\Role;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-  Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
-  Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
 });
 
 // ============================================================
@@ -19,105 +19,129 @@ beforeEach(function () {
 // ============================================================
 
 test('super admin can list all users', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  User::factory()->count(3)->create();
+    User::factory()->count(3)->create();
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson('/api/v1/admin/users');
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users');
 
-  $response->assertStatus(200)
-    ->assertJsonCount(4, 'data.items') // 3 + admin
-    ->assertJsonPath('data.total', 4)
-    ->assertJsonPath('data.per_page', 15)
-    ->assertJsonPath('data.current_page', 1);
+    $response->assertStatus(200)
+        ->assertJsonCount(4, 'data.items') // 3 + admin
+        ->assertJsonPath('data.total', 4)
+        ->assertJsonPath('data.per_page', 15)
+        ->assertJsonPath('data.current_page', 1);
 });
 
 test('store admin only sees users from their store', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  User::factory()->count(2)->create(['store_id' => $store->id]);
-  User::factory()->count(3)->create(); // other store
+    User::factory()->count(2)->create(['store_id' => $store->id]);
+    User::factory()->count(3)->create(); // other store
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson('/api/v1/admin/users');
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users');
 
-  $response->assertStatus(200)
-    ->assertJsonCount(3, 'data.items') // 2 + admin
-    ->assertJsonPath('data.total', 3);
+    $response->assertStatus(200)
+        ->assertJsonCount(3, 'data.items') // 2 + admin
+        ->assertJsonPath('data.total', 3);
 });
 
 test('index filters users by name', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  User::factory()->create(['name' => 'Juan Perez']);
-  User::factory()->create(['name' => 'Maria Lopez']);
-  User::factory()->create(['name' => 'Juan Garcia']);
+    User::factory()->create(['name' => 'Juan Perez']);
+    User::factory()->create(['name' => 'Maria Lopez']);
+    User::factory()->create(['name' => 'Juan Garcia']);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson('/api/v1/admin/users?name=Juan');
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users?name=Juan');
 
-  $response->assertStatus(200)
-    ->assertJsonCount(2, 'data.items')
-    ->assertJsonPath('data.total', 2);
+    $response->assertStatus(200)
+        ->assertJsonCount(2, 'data.items')
+        ->assertJsonPath('data.total', 2);
 });
 
 test('index filters users by role', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user1 = User::factory()->create();
-  $user1->assignRole('STORE_ADMIN');
+    $user1 = User::factory()->create();
+    $user1->assignRole('STORE_ADMIN');
 
-  $user2 = User::factory()->create();
-  $user2->assignRole('STORE_ADMIN');
+    $user2 = User::factory()->create();
+    $user2->assignRole('STORE_ADMIN');
 
-  User::factory()->create(); // no role
+    User::factory()->create(); // no role
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson('/api/v1/admin/users?role=STORE_ADMIN');
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users?role=STORE_ADMIN');
 
-  $response->assertStatus(200)
-    ->assertJsonCount(2, 'data.items')
-    ->assertJsonPath('data.total', 2);
+    $response->assertStatus(200)
+        ->assertJsonCount(2, 'data.items')
+        ->assertJsonPath('data.total', 2);
 });
 
 test('super admin can filter by store_id', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $store = Store::factory()->create();
-  User::factory()->count(2)->create(['store_id' => $store->id]);
-  User::factory()->count(3)->create(); // other store
+    $store = Store::factory()->create();
+    User::factory()->count(2)->create(['store_id' => $store->id]);
+    User::factory()->count(3)->create(); // other store
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson("/api/v1/admin/users?store_id={$store->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson("/api/v1/admin/users?store_id={$store->id}");
 
-  $response->assertStatus(200)
-    ->assertJsonCount(2, 'data.items')
-    ->assertJsonPath('data.total', 2);
+    $response->assertStatus(200)
+        ->assertJsonCount(2, 'data.items')
+        ->assertJsonPath('data.total', 2);
+});
+
+test('super admin can filter by is_active', function () {
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
+
+    User::factory()->count(2)->create(['is_active' => true]);
+    User::factory()->count(3)->create(['is_active' => false]);
+
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users?is_active=true');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(3, 'data.items')
+        ->assertJsonPath('data.total', 3);
+
+    $response2 = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users?is_active=false');
+
+    $response2->assertStatus(200)
+        ->assertJsonCount(3, 'data.items')
+        ->assertJsonPath('data.total', 3);
 });
 
 test('index rejects unauthenticated request', function () {
-  /** @var \Tests\TestCase $this */
-  $response = $this->getJson('/api/v1/admin/users');
+    /** @var \Tests\TestCase $this */
+    $response = $this->getJson('/api/v1/admin/users');
 
-  $response->assertStatus(401);
+    $response->assertStatus(401);
 });
 
 // ============================================================
@@ -125,144 +149,144 @@ test('index rejects unauthenticated request', function () {
 // ============================================================
 
 test('super admin can create user in any store', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $store = Store::factory()->create();
+    $store = Store::factory()->create();
 
-  $data = [
-    'name'                  => 'Nuevo Usuario',
-    'email'                 => 'nuevo@centra.com',
-    'password'              => 'Password1',
-    'password_confirmation' => 'Password1',
-    'role'                  => 'STORE_ADMIN',
-    'store_id'              => $store->id,
-  ];
+    $data = [
+        'name' => 'Nuevo Usuario',
+        'email' => 'nuevo@centra.com',
+        'password' => 'Password1',
+        'password_confirmation' => 'Password1',
+        'role' => 'STORE_ADMIN',
+        'store_id' => $store->id,
+    ];
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->postJson('/api/v1/admin/users', $data);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->postJson('/api/v1/admin/users', $data);
 
-  $response->assertStatus(201)
-    ->assertJsonPath('data.name', 'Nuevo Usuario')
-    ->assertJsonPath('data.email', 'nuevo@centra.com');
+    $response->assertStatus(201)
+        ->assertJsonPath('data.name', 'Nuevo Usuario')
+        ->assertJsonPath('data.email', 'nuevo@centra.com');
 
-  $this->assertDatabaseHas('users', ['email' => 'nuevo@centra.com', 'store_id' => $store->id]);
+    $this->assertDatabaseHas('users', ['email' => 'nuevo@centra.com', 'store_id' => $store->id]);
 });
 
 test('store admin creates user in their own store ignoring store_id sent', function () {
-  /** @var \Tests\TestCase $this */
-  $plan = Plan::create(['name' => 'Plan Pro', 'price' => 99, 'billing_cycle' => 'monthly', 'is_active' => true]);
-  $feature = Feature::create(['code' => 'multi_user', 'name' => 'Multi-Usuario', 'description' => 'Creación de múltiples cuentas.']);
-  $plan->features()->attach($feature->id, ['limit_value' => 5]);
+    /** @var \Tests\TestCase $this */
+    $plan = Plan::create(['name' => 'Plan Pro', 'price' => 99, 'billing_cycle' => 'monthly', 'is_active' => true]);
+    $feature = Feature::create(['code' => 'multi_user', 'name' => 'Multi-Usuario', 'description' => 'Creación de múltiples cuentas.']);
+    $plan->features()->attach($feature->id, ['limit_value' => 5]);
 
-  $store = Store::factory()->create(['plan_id' => $plan->id]);
-  $otherStore = Store::factory()->create();
+    $store = Store::factory()->create(['plan_id' => $plan->id]);
+    $otherStore = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $data = [
-    'name'                  => 'Nuevo Usuario',
-    'email'                 => 'nuevo@centra.com',
-    'password'              => 'Password1',
-    'password_confirmation' => 'Password1',
-    'role'                  => 'STORE_ADMIN',
-    'store_id'              => $otherStore->id, // should be ignored
-  ];
+    $data = [
+        'name' => 'Nuevo Usuario',
+        'email' => 'nuevo@centra.com',
+        'password' => 'Password1',
+        'password_confirmation' => 'Password1',
+        'role' => 'STORE_ADMIN',
+        'store_id' => $otherStore->id, // should be ignored
+    ];
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->postJson('/api/v1/admin/users', $data);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->postJson('/api/v1/admin/users', $data);
 
-  $response->assertStatus(201);
+    $response->assertStatus(201);
 
-  $this->assertDatabaseHas('users', [
-    'email'    => 'nuevo@centra.com',
-    'store_id' => $store->id, // assigned to admin's store, not otherStore
-  ]);
+    $this->assertDatabaseHas('users', [
+        'email' => 'nuevo@centra.com',
+        'store_id' => $store->id, // assigned to admin's store, not otherStore
+    ]);
 });
 
 test('store admin cannot assign super admin role', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $data = [
-    'name'                  => 'Nuevo Admin',
-    'email'                 => 'admin@centra.com',
-    'password'              => 'Password1',
-    'password_confirmation' => 'Password1',
-    'role'                  => 'SUPER_ADMIN',
-  ];
+    $data = [
+        'name' => 'Nuevo Admin',
+        'email' => 'admin@centra.com',
+        'password' => 'Password1',
+        'password_confirmation' => 'Password1',
+        'role' => 'SUPER_ADMIN',
+    ];
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->postJson('/api/v1/admin/users', $data);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->postJson('/api/v1/admin/users', $data);
 
-  $response->assertStatus(403)
-    ->assertJsonPath('message', 'No tenés permisos para asignar ese rol.');
+    $response->assertStatus(403)
+        ->assertJsonPath('message', 'No tenés permisos para asignar ese rol.');
 });
 
 test('store fails validation with invalid data', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->postJson('/api/v1/admin/users', []);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->postJson('/api/v1/admin/users', []);
 
-  $response->assertStatus(422)
-    ->assertJsonPath('message', 'Error de validación.')
-    ->assertJsonStructure(['errors' => ['name', 'email', 'password', 'role']]);
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'Error de validación.')
+        ->assertJsonStructure(['errors' => ['name', 'email', 'password', 'role']]);
 });
 
 test('store rejects request without role', function () {
-  /** @var \Tests\TestCase $this */
-  $user = User::factory()->create();
-  $token = $user->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $user = User::factory()->create();
+    $token = $user->createToken('test-token')->plainTextToken;
 
-  $data = [
-    'name'                  => 'Nuevo Usuario',
-    'email'                 => 'nuevo@centra.com',
-    'password'              => 'Password1',
-    'password_confirmation' => 'Password1',
-    'role'                  => 'STORE_ADMIN',
-  ];
+    $data = [
+        'name' => 'Nuevo Usuario',
+        'email' => 'nuevo@centra.com',
+        'password' => 'Password1',
+        'password_confirmation' => 'Password1',
+        'role' => 'STORE_ADMIN',
+    ];
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->postJson('/api/v1/admin/users', $data);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->postJson('/api/v1/admin/users', $data);
 
-  $response->assertStatus(403);
+    $response->assertStatus(403);
 });
 
 test('store generates uuid automatically for new user', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $data = [
-    'name'                  => 'UUID User',
-    'email'                 => 'uuid@centra.com',
-    'password'              => 'Password1',
-    'password_confirmation' => 'Password1',
-    'role'                  => 'STORE_ADMIN',
-  ];
+    $data = [
+        'name' => 'UUID User',
+        'email' => 'uuid@centra.com',
+        'password' => 'Password1',
+        'password_confirmation' => 'Password1',
+        'role' => 'STORE_ADMIN',
+    ];
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->postJson('/api/v1/admin/users', $data);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->postJson('/api/v1/admin/users', $data);
 
-  $response->assertStatus(201);
+    $response->assertStatus(201);
 
-  $user = User::where('email', 'uuid@centra.com')->first();
-  expect($user)->not->toBeNull();
-  expect(preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $user->id))->toBe(1);
-  expect($user->store_id)->toBeNull();
+    $user = User::where('email', 'uuid@centra.com')->first();
+    expect($user)->not->toBeNull();
+    expect(preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $user->id))->toBe(1);
+    expect($user->store_id)->toBeNull();
 });
 
 // ============================================================
@@ -270,67 +294,67 @@ test('store generates uuid automatically for new user', function () {
 // ============================================================
 
 test('super admin can view any user', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create();
+    $user = User::factory()->create();
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson("/api/v1/admin/users/{$user->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson("/api/v1/admin/users/{$user->id}");
 
-  $response->assertStatus(200)
-    ->assertJsonPath('data.id', $user->id)
-    ->assertJsonPath('data.email', $user->email);
+    $response->assertStatus(200)
+        ->assertJsonPath('data.id', $user->id)
+        ->assertJsonPath('data.email', $user->email);
 });
 
 test('show store admin can view user from their store', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create(['store_id' => $store->id]);
+    $user = User::factory()->create(['store_id' => $store->id]);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson("/api/v1/admin/users/{$user->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson("/api/v1/admin/users/{$user->id}");
 
-  $response->assertStatus(200)
-    ->assertJsonPath('data.id', $user->id);
+    $response->assertStatus(200)
+        ->assertJsonPath('data.id', $user->id);
 });
 
 test('show returns 404 for non-existent user', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson('/api/v1/admin/users/00000000-0000-0000-0000-000000000000');
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson('/api/v1/admin/users/00000000-0000-0000-0000-000000000000');
 
-  $response->assertStatus(404)
-    ->assertJsonPath('message', 'Usuario no encontrado.');
+    $response->assertStatus(404)
+        ->assertJsonPath('message', 'Usuario no encontrado.');
 });
 
 test('store admin cannot view users from another store', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
-  $otherStore = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
+    $otherStore = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $otherUser = User::factory()->create(['store_id' => $otherStore->id]);
+    $otherUser = User::factory()->create(['store_id' => $otherStore->id]);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->getJson("/api/v1/admin/users/{$otherUser->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->getJson("/api/v1/admin/users/{$otherUser->id}");
 
-  $response->assertStatus(404)
-    ->assertJsonPath('message', 'Usuario no encontrado.');
+    $response->assertStatus(404)
+        ->assertJsonPath('message', 'Usuario no encontrado.');
 });
 
 // ============================================================
@@ -338,92 +362,147 @@ test('store admin cannot view users from another store', function () {
 // ============================================================
 
 test('super admin can update any user', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create(['name' => 'Old Name']);
+    $user = User::factory()->create(['name' => 'Old Name']);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->putJson("/api/v1/admin/users/{$user->id}", ['name' => 'New Name']);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['name' => 'New Name']);
 
-  $response->assertStatus(200)
-    ->assertJsonPath('data.name', 'New Name');
+    $response->assertStatus(200)
+        ->assertJsonPath('data.name', 'New Name');
 
-  $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => 'New Name']);
+    $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => 'New Name']);
 });
 
 test('store admin can update users from their store', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create(['store_id' => $store->id, 'name' => 'Old Name']);
+    $user = User::factory()->create(['store_id' => $store->id, 'name' => 'Old Name']);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->putJson("/api/v1/admin/users/{$user->id}", ['name' => 'Updated']);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['name' => 'Updated']);
 
-  $response->assertStatus(200)
-    ->assertJsonPath('data.name', 'Updated');
+    $response->assertStatus(200)
+        ->assertJsonPath('data.name', 'Updated');
 });
 
 test('store admin cannot assign super admin role on update', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create(['store_id' => $store->id]);
+    $user = User::factory()->create(['store_id' => $store->id]);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->putJson("/api/v1/admin/users/{$user->id}", ['role' => 'SUPER_ADMIN']);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['role' => 'SUPER_ADMIN']);
 
-  $response->assertStatus(403)
-    ->assertJsonPath('message', 'No tenés permisos para asignar ese rol.');
+    $response->assertStatus(403)
+        ->assertJsonPath('message', 'No tenés permisos para asignar ese rol.');
 });
 
 test('super admin can change store_id on update', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $store1 = Store::factory()->create();
-  $store2 = Store::factory()->create();
+    $store1 = Store::factory()->create();
+    $store2 = Store::factory()->create();
 
-  $user = User::factory()->create(['store_id' => $store1->id]);
+    $user = User::factory()->create(['store_id' => $store1->id]);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->putJson("/api/v1/admin/users/{$user->id}", ['store_id' => $store2->id]);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['store_id' => $store2->id]);
 
-  $response->assertStatus(200);
+    $response->assertStatus(200);
 
-  $this->assertDatabaseHas('users', ['id' => $user->id, 'store_id' => $store2->id]);
+    $this->assertDatabaseHas('users', ['id' => $user->id, 'store_id' => $store2->id]);
 });
 
 test('update does partial update correctly', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create([
-    'name'  => 'Original Name',
-    'email' => 'original@centra.com',
-  ]);
+    $user = User::factory()->create([
+        'name' => 'Original Name',
+        'email' => 'original@centra.com',
+    ]);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->putJson("/api/v1/admin/users/{$user->id}", ['name' => 'Changed Name']);
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['name' => 'Changed Name']);
 
-  $response->assertStatus(200)
-    ->assertJsonPath('data.name', 'Changed Name')
-    ->assertJsonPath('data.email', 'original@centra.com'); // unchanged
+    $response->assertStatus(200)
+        ->assertJsonPath('data.name', 'Changed Name')
+        ->assertJsonPath('data.email', 'original@centra.com'); // unchanged
+});
+
+test('super admin can deactivate a user', function () {
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
+
+    $user = User::factory()->create(['is_active' => true]);
+
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['is_active' => false]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.is_active', false);
+
+    $this->assertDatabaseHas('users', ['id' => $user->id, 'is_active' => false]);
+});
+
+test('super admin can reactivate a user', function () {
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
+
+    $user = User::factory()->create(['is_active' => false]);
+
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['is_active' => true]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.is_active', true);
+
+    $this->assertDatabaseHas('users', ['id' => $user->id, 'is_active' => true]);
+});
+
+test('store admin can change is_active', function () {
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
+
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
+
+    $user = User::factory()->create(['store_id' => $store->id, 'is_active' => true]);
+
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->putJson("/api/v1/admin/users/{$user->id}", ['is_active' => false, 'name' => 'Updated']);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.is_active', false);
+
+    $user->refresh();
+    expect($user->is_active)->toBe(false);
+    expect($user->name)->toBe('Updated');
 });
 
 // ============================================================
@@ -431,63 +510,63 @@ test('update does partial update correctly', function () {
 // ============================================================
 
 test('user cannot delete themselves', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->deleteJson("/api/v1/admin/users/{$admin->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->deleteJson("/api/v1/admin/users/{$admin->id}");
 
-  $response->assertStatus(403)
-    ->assertJsonPath('message', 'No podés eliminar tu propio usuario.');
+    $response->assertStatus(403)
+        ->assertJsonPath('message', 'No podés eliminar tu propio usuario.');
 
-  $this->assertDatabaseHas('users', ['id' => $admin->id]);
+    $this->assertDatabaseHas('users', ['id' => $admin->id]);
 });
 
 test('super admin can delete a user', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create();
+    $user = User::factory()->create();
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->deleteJson("/api/v1/admin/users/{$user->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->deleteJson("/api/v1/admin/users/{$user->id}");
 
-  $response->assertStatus(200)
-    ->assertJsonPath('message', 'Usuario eliminado correctamente.');
+    $response->assertStatus(200)
+        ->assertJsonPath('message', 'Usuario eliminado correctamente.');
 
-  $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    $this->assertDatabaseMissing('users', ['id' => $user->id]);
 });
 
 test('store admin can only delete users from their store', function () {
-  /** @var \Tests\TestCase $this */
-  $store = Store::factory()->create();
+    /** @var \Tests\TestCase $this */
+    $store = Store::factory()->create();
 
-  $admin = User::factory()->create(['store_id' => $store->id]);
-  $admin->assignRole('STORE_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    $admin = User::factory()->create(['store_id' => $store->id]);
+    $admin->assignRole('STORE_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $user = User::factory()->create(['store_id' => $store->id]);
+    $user = User::factory()->create(['store_id' => $store->id]);
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->deleteJson("/api/v1/admin/users/{$user->id}");
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->deleteJson("/api/v1/admin/users/{$user->id}");
 
-  $response->assertStatus(200);
+    $response->assertStatus(200);
 
-  $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    $this->assertDatabaseMissing('users', ['id' => $user->id]);
 });
 
 test('destroy returns 404 for non-existent user', function () {
-  /** @var \Tests\TestCase $this */
-  $admin = User::factory()->create();
-  $admin->assignRole('SUPER_ADMIN');
-  $token = $admin->createToken('test-token')->plainTextToken;
+    /** @var \Tests\TestCase $this */
+    $admin = User::factory()->create();
+    $admin->assignRole('SUPER_ADMIN');
+    $token = $admin->createToken('test-token')->plainTextToken;
 
-  $response = $this->withHeader('Authorization', "Bearer $token")
-    ->deleteJson('/api/v1/admin/users/00000000-0000-0000-0000-000000000000');
+    $response = $this->withHeader('Authorization', "Bearer $token")
+        ->deleteJson('/api/v1/admin/users/00000000-0000-0000-0000-000000000000');
 
-  $response->assertStatus(404);
+    $response->assertStatus(404);
 });

--- a/tests/Feature/Api/V1/AuthTest.php
+++ b/tests/Feature/Api/V1/AuthTest.php
@@ -7,139 +7,172 @@ use App\Models\Plan;
 use App\Models\Store;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 use Spatie\Permission\Models\Role;
+use Tests\TestCase;
 
 class AuthTest extends TestCase
 {
-  use RefreshDatabase;
+    use RefreshDatabase;
 
-  protected function setUp(): void
-  {
-    parent::setUp();
+    protected function setUp(): void
+    {
+        parent::setUp();
 
-    Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
-  }
+        Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
+    }
 
-  /** @test */
-  public function a_user_can_login_with_correct_credentials()
-  {
-    $plan = Plan::factory()->create();
-    $feature = Feature::factory()->create(['code' => 'feature1']);
-    $plan->features()->attach($feature);
+    /** @test */
+    public function a_user_can_login_with_correct_credentials()
+    {
+        $plan = Plan::factory()->create();
+        $feature = Feature::factory()->create(['code' => 'feature1']);
+        $plan->features()->attach($feature);
 
-    $store = Store::factory()->create(['plan_id' => $plan->id]);
+        $store = Store::factory()->create(['plan_id' => $plan->id]);
 
-    $user = User::factory()->create([
-      'email' => 'test@centra.com',
-      'password' => bcrypt('password123'),
-      'store_id' => $store->id,
-    ]);
-    $user->assignRole('SUPER_ADMIN');
+        $user = User::factory()->create([
+            'email' => 'test@centra.com',
+            'password' => bcrypt('password123'),
+            'store_id' => $store->id,
+        ]);
+        $user->assignRole('SUPER_ADMIN');
 
-    $response = $this->postJson('/api/v1/login', [
-      'email' => 'test@centra.com',
-      'password' => 'password123',
-    ]);
+        $response = $this->postJson('/api/v1/login', [
+            'email' => 'test@centra.com',
+            'password' => 'password123',
+        ]);
 
-    $response->assertStatus(200)
-      ->assertJsonStructure([
-        'data' => [
-          'token',
-          'user' => ['id', 'name', 'email', 'store', 'roles', 'permissions', 'features']
-        ],
-        'message'
-      ])
-      ->assertJsonPath('data.user.email', 'test@centra.com')
-      ->assertJsonPath('data.user.roles.0', 'SUPER_ADMIN')
-      ->assertJsonPath('data.user.features.0.code', 'feature1');
-  }
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'token',
+                    'user' => ['id', 'name', 'email', 'is_active', 'store', 'roles', 'permissions', 'features'],
+                ],
+                'message',
+            ])
+            ->assertJsonPath('data.user.email', 'test@centra.com')
+            ->assertJsonPath('data.user.is_active', true)
+            ->assertJsonPath('data.user.roles.0', 'SUPER_ADMIN')
+            ->assertJsonPath('data.user.features.0.code', 'feature1');
+    }
 
-  /** @test */
-  public function a_user_cannot_login_with_incorrect_password()
-  {
-    User::factory()->create([
-      'email' => 'test@centra.com',
-      'password' => bcrypt('password123'),
-    ]);
+    /** @test */
+    public function an_inactive_user_cannot_login()
+    {
+        $user = User::factory()->create([
+            'email' => 'inactive@centra.com',
+            'password' => bcrypt('password123'),
+            'is_active' => false,
+        ]);
 
-    $response = $this->postJson('/api/v1/login', [
-      'email' => 'test@centra.com',
-      'password' => 'wrong-password',
-    ]);
+        $response = $this->postJson('/api/v1/login', [
+            'email' => 'inactive@centra.com',
+            'password' => 'password123',
+        ]);
 
-    $response->assertStatus(401)
-      ->assertJsonPath('message', 'Credenciales inválidas.');
-  }
+        $response->assertStatus(403)
+            ->assertJsonPath('message', 'Tu cuenta está desactivada.')
+            ->assertJsonPath('errors.auth.0', 'Tu cuenta está desactivada. Contactá al administrador de la tienda.');
+    }
 
-  /** @test */
-  public function an_authenticated_user_can_get_their_data()
-  {
-    $plan = Plan::factory()->create();
-    $feature1 = Feature::factory()->create(['code' => 'feature1']);
-    $feature2 = Feature::factory()->create(['code' => 'feature2']);
-    $plan->features()->attach([$feature1->id, $feature2->id]);
+    /** @test */
+    public function me_endpoint_includes_is_active_field()
+    {
+        $user = User::factory()->create(['is_active' => true]);
+        $user->assignRole('SUPER_ADMIN');
+        $token = $user->createToken('test-token')->plainTextToken;
 
-    $store = Store::factory()->create(['plan_id' => $plan->id]);
+        $response = $this->withHeader('Authorization', "Bearer $token")
+            ->getJson('/api/v1/me');
 
-    $user = User::factory()->create(['store_id' => $store->id]);
-    $user->assignRole('SUPER_ADMIN');
-    $token = $user->createToken('test-token')->plainTextToken;
+        $response->assertStatus(200)
+            ->assertJsonPath('data.user.is_active', true);
+    }
 
-    $response = $this->withHeader('Authorization', "Bearer $token")
-      ->getJson('/api/v1/me');
+    /** @test */
+    public function a_user_cannot_login_with_incorrect_password()
+    {
+        User::factory()->create([
+            'email' => 'test@centra.com',
+            'password' => bcrypt('password123'),
+        ]);
 
-    $response->assertStatus(200)
-      ->assertJsonStructure([
-        'data' => [
-          'user' => ['id', 'name', 'email', 'store', 'roles', 'permissions', 'features']
-        ]
-      ])
-      ->assertJsonPath('data.user.email', $user->email)
-      ->assertJsonCount(2, 'data.user.features')
-      ->assertJsonPath('data.user.features.0.code', 'feature1');
-  }
+        $response = $this->postJson('/api/v1/login', [
+            'email' => 'test@centra.com',
+            'password' => 'wrong-password',
+        ]);
 
-  /** @test */
-  public function a_user_can_logout()
-  {
-    $user = User::factory()->create();
-    $token = $user->createToken('test-token')->plainTextToken;
+        $response->assertStatus(401)
+            ->assertJsonPath('message', 'Credenciales inválidas.');
+    }
 
+    /** @test */
+    public function an_authenticated_user_can_get_their_data()
+    {
+        $plan = Plan::factory()->create();
+        $feature1 = Feature::factory()->create(['code' => 'feature1']);
+        $feature2 = Feature::factory()->create(['code' => 'feature2']);
+        $plan->features()->attach([$feature1->id, $feature2->id]);
 
-    $this->withHeader('Authorization', "Bearer $token")
-      ->postJson('/api/v1/logout')
-      ->assertStatus(200);
+        $store = Store::factory()->create(['plan_id' => $plan->id]);
 
-    $this->assertDatabaseCount('personal_access_tokens', 0);
-  }
+        $user = User::factory()->create(['store_id' => $store->id]);
+        $user->assignRole('SUPER_ADMIN');
+        $token = $user->createToken('test-token')->plainTextToken;
 
-  /** @test */
-  public function a_user_without_store_has_empty_features_array()
-  {
-    $user = User::factory()->create(['store_id' => null]);
-    $user->assignRole('SUPER_ADMIN');
-    $token = $user->createToken('test-token')->plainTextToken;
+        $response = $this->withHeader('Authorization', "Bearer $token")
+            ->getJson('/api/v1/me');
 
-    $response = $this->withHeader('Authorization', "Bearer $token")
-      ->getJson('/api/v1/me');
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'user' => ['id', 'name', 'email', 'store', 'roles', 'permissions', 'features'],
+                ],
+            ])
+            ->assertJsonPath('data.user.email', $user->email)
+            ->assertJsonCount(2, 'data.user.features')
+            ->assertJsonPath('data.user.features.0.code', 'feature1');
+    }
 
-    $response->assertStatus(200)
-      ->assertJsonPath('data.user.features', []);
-  }
+    /** @test */
+    public function a_user_can_logout()
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-token')->plainTextToken;
 
-  /** @test */
-  public function a_user_with_store_without_plan_has_empty_features_array()
-  {
-    $store = Store::factory()->create(['plan_id' => null]);
-    $user = User::factory()->create(['store_id' => $store->id]);
-    $user->assignRole('SUPER_ADMIN');
-    $token = $user->createToken('test-token')->plainTextToken;
+        $this->withHeader('Authorization', "Bearer $token")
+            ->postJson('/api/v1/logout')
+            ->assertStatus(200);
 
-    $response = $this->withHeader('Authorization', "Bearer $token")
-      ->getJson('/api/v1/me');
+        $this->assertDatabaseCount('personal_access_tokens', 0);
+    }
 
-    $response->assertStatus(200)
-      ->assertJsonPath('data.user.features', []);
-  }
+    /** @test */
+    public function a_user_without_store_has_empty_features_array()
+    {
+        $user = User::factory()->create(['store_id' => null]);
+        $user->assignRole('SUPER_ADMIN');
+        $token = $user->createToken('test-token')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer $token")
+            ->getJson('/api/v1/me');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.user.features', []);
+    }
+
+    /** @test */
+    public function a_user_with_store_without_plan_has_empty_features_array()
+    {
+        $store = Store::factory()->create(['plan_id' => null]);
+        $user = User::factory()->create(['store_id' => $store->id]);
+        $user->assignRole('SUPER_ADMIN');
+        $token = $user->createToken('test-token')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', "Bearer $token")
+            ->getJson('/api/v1/me');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.user.features', []);
+    }
 }


### PR DESCRIPTION
- Added 'is_active' field to user data structure in login response.
- Implemented test for inactive users to ensure they cannot log in.
- Updated 'me' endpoint test to verify inclusion of 'is_active' field.
- Cleaned up test structure for better readability and consistency.