### PR TITLE
feat: Implement cancel order functionality for commercial operations

### DIFF
--- a/app/Http/Controllers/Api/V1/Store/CommercialOperationController.php
+++ b/app/Http/Controllers/Api/V1/Store/CommercialOperationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1\Store;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Store\CancelOrderRequest;
 use App\Http\Requests\Api\V1\Store\ListCommercialOperationsRequest;
 use App\Http\Requests\Api\V1\Store\RescheduleDeliveryDateRequest;
 use App\Http\Requests\Api\V1\Store\StoreCommercialOperationRequest;
@@ -299,6 +300,91 @@ class CommercialOperationController extends Controller
             return response()->json([
                 'status' => 'success',
                 'message' => 'Operación reprogramada exitosamente.',
+                'data' => CommercialOperationResource::make($operation),
+                'errors' => null,
+            ], 200);
+        } catch (ValidationException $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Cancel a commercial operation (order only, open status only).
+     *
+     * @OA\Put(
+     *   path="/store/operations/{operation}/cancel",
+     *   summary="Cancelar un pedido",
+     *   tags={"Store - Operaciones Comerciales"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="operation", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *
+     *   @OA\RequestBody(
+     *     required=true,
+     *
+     *     @OA\JsonContent(
+     *       required={"reason_code"},
+     *
+     *       @OA\Property(property="reason_code", type="string", enum={"customer_cancelled", "payment_failed", "out_of_stock", "pricing_error", "duplicate_order", "other"}, example="customer_cancelled"),
+     *       @OA\Property(property="reason_note", type="string", nullable=true, example="El cliente ya no necesita el pedido.")
+     *     )
+     *   ),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Operación cancelada exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="string", example="Operación cancelada exitosamente."),
+     *       @OA\Property(property="data", ref="#/components/schemas/CommercialOperationResource"),
+     *       @OA\Property(property="errors", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=403, description="Sin permisos"),
+     *   @OA\Response(response=404, description="Operación no encontrada"),
+     *   @OA\Response(response=422, description="Error de validación")
+     * )
+     */
+    public function cancel(
+        CancelOrderRequest $request,
+        CommercialOperationService $service,
+        string $id
+    ): JsonResponse {
+        $storeId = $request->user()->store_id;
+
+        $operation = CommercialOperation::forStore($storeId)->find($id);
+
+        if (! $operation) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Operación comercial no encontrada.',
+                'data' => null,
+                'errors' => ['id' => ['La operación comercial no existe o no pertenece a tu tienda.']],
+            ], 404);
+        }
+
+        try {
+            $operation = $service->cancel(
+                $operation,
+                $request->validated('reason_code'),
+                $request->validated('reason_note'),
+                $request->user()
+            );
+
+            $operation->load([
+                'customer',
+                'user',
+                'items.product',
+                'payments.storePaymentMethod.paymentMethod',
+                'events.user',
+            ]);
+
+            return response()->json([
+                'status' => 'success',
+                'message' => 'Operación cancelada exitosamente.',
                 'data' => CommercialOperationResource::make($operation),
                 'errors' => null,
             ], 200);

--- a/app/Http/Requests/Api/V1/Store/CancelOrderRequest.php
+++ b/app/Http/Requests/Api/V1/Store/CancelOrderRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Store;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CancelOrderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'reason_code' => ['required', 'string', 'in:customer_cancelled,payment_failed,out_of_stock,pricing_error,duplicate_order,other'],
+            'reason_note' => ['required_if:reason_code,other', 'nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'reason_code.required' => 'El motivo de cancelación es obligatorio.',
+            'reason_code.in' => 'El motivo seleccionado no es válido.',
+            'reason_note.required_if' => 'La nota es obligatoria cuando el motivo es "otro".',
+            'reason_note.max' => 'La nota no puede superar los 1000 caracteres.',
+        ];
+    }
+}

--- a/app/Http/Resources/CommercialOperationEventResource.php
+++ b/app/Http/Resources/CommercialOperationEventResource.php
@@ -14,7 +14,11 @@ class CommercialOperationEventResource extends JsonResource
             'event_type' => $this->event_type,
             'previous_date' => $this->previous_date?->format('Y-m-d'),
             'new_date' => $this->new_date?->format('Y-m-d'),
+            'previous_status' => $this->previous_status,
+            'new_status' => $this->new_status,
             'reason' => $this->reason,
+            'reason_code' => $this->reason_code,
+            'reason_note' => $this->reason_note,
             'observation' => $this->observation,
             'user' => $this->whenLoaded('user', fn () => [
                 'id' => $this->user_id,

--- a/app/Models/CommercialOperationEvent.php
+++ b/app/Models/CommercialOperationEvent.php
@@ -27,6 +27,10 @@ class CommercialOperationEvent extends Model
         'reason',
         'observation',
         'user_id',
+        'previous_status',
+        'new_status',
+        'reason_code',
+        'reason_note',
     ];
 
     protected function casts(): array
@@ -35,6 +39,9 @@ class CommercialOperationEvent extends Model
             'previous_date' => 'date',
             'new_date' => 'date',
             'created_at' => 'datetime',
+            'previous_status' => 'string',
+            'new_status' => 'string',
+            'reason_code' => 'string',
         ];
     }
 

--- a/app/Services/CommercialOperationService.php
+++ b/app/Services/CommercialOperationService.php
@@ -180,6 +180,74 @@ class CommercialOperationService
         });
     }
 
+    public function cancel(
+        CommercialOperation $operation,
+        string $reasonCode,
+        ?string $reasonNote,
+        User $user
+    ): CommercialOperation {
+        return DB::transaction(function () use ($operation, $reasonCode, $reasonNote, $user) {
+            $operation = CommercialOperation::where('id', $operation->id)->lockForUpdate()->firstOrFail();
+
+            if ($operation->type !== 'order') {
+                throw ValidationException::withMessages([
+                    'type' => ['Solo los pedidos pueden ser cancelados.'],
+                ]);
+            }
+
+            if ($operation->status !== 'open') {
+                throw ValidationException::withMessages([
+                    'status' => ['Solo los pedidos abiertos pueden ser cancelados.'],
+                ]);
+            }
+
+            $previousDate = $operation->requested_delivery_date?->format('Y-m-d');
+
+            CommercialOperationEvent::create([
+                'store_id' => $operation->store_id,
+                'operation_id' => $operation->id,
+                'event_type' => 'order_cancelled',
+                'previous_date' => $previousDate,
+                'new_date' => null,
+                'reason' => $reasonCode,
+                'observation' => $reasonNote,
+                'user_id' => $user->id,
+                'previous_status' => 'open',
+                'new_status' => 'cancelled',
+                'reason_code' => $reasonCode,
+                'reason_note' => $reasonNote,
+            ]);
+
+            // Release stock_reserved for future deliveries
+            if ($operation->requested_delivery_date && $operation->requested_delivery_date->isFuture()) {
+                $items = $operation->items;
+
+                foreach ($items as $item) {
+                    $product = Product::forStore($operation->store_id)
+                        ->lockForUpdate()
+                        ->find($item->product_id);
+
+                    if ($product) {
+                        $product->stock_reserved = max(0, $product->stock_reserved - $item->quantity);
+                        $product->save();
+
+                        if (! Product::validateStockIntegrity($product->stock, $product->stock_reserved)) {
+                            throw new \RuntimeException(
+                                "Stock integrity violation on product {$product->id}: stock={$product->stock}, reserved={$product->stock_reserved}"
+                            );
+                        }
+                    }
+                }
+            }
+
+            $operation->update([
+                'status' => 'cancelled',
+            ]);
+
+            return $operation->fresh();
+        });
+    }
+
     private function validateBusinessRules(array $data, string $storeId): void
     {
         $type = $data['type'];

--- a/database/migrations/2026_07_22_000001_add_cancellation_columns_to_commercial_operation_events_table.php
+++ b/database/migrations/2026_07_22_000001_add_cancellation_columns_to_commercial_operation_events_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('commercial_operation_events', function (Blueprint $table) {
+            $table->string('previous_status', 20)->nullable()->after('event_type');
+            $table->string('new_status', 20)->nullable()->after('previous_status');
+            $table->string('reason_code', 50)->nullable()->after('new_status');
+            $table->text('reason_note')->nullable()->after('reason_code');
+
+            // Make new_date nullable for cancellation events (where it is always null)
+            $table->date('new_date')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('commercial_operation_events', function (Blueprint $table) {
+            $table->dropColumn(['previous_status', 'new_status', 'reason_code', 'reason_note']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -148,6 +148,9 @@ Route::prefix('v1')->group(function () {
                 Route::put('operations/{operation}/reschedule', [CommercialOperationController::class, 'reschedule'])
                     ->middleware('permission:orders.edit')
                     ->name('store.operations.reschedule');
+                Route::put('operations/{operation}/cancel', [CommercialOperationController::class, 'cancel'])
+                    ->middleware('permission:orders.edit')
+                    ->name('store.operations.cancel');
             });
 
             Route::middleware('feature:customers')->group(function () {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -9222,6 +9222,102 @@
                 ]
             }
         },
+        "/store/operations/{operation}/cancel": {
+            "put": {
+                "tags": [
+                    "Store - Operaciones Comerciales"
+                ],
+                "summary": "Cancelar un pedido",
+                "description": "Cancel a commercial operation (order only, open status only).",
+                "operationId": "1e44766cee806edc62d9574d02fa7339",
+                "parameters": [
+                    {
+                        "name": "operation",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "reason_code"
+                                ],
+                                "properties": {
+                                    "reason_code": {
+                                        "type": "string",
+                                        "enum": [
+                                            "customer_cancelled",
+                                            "payment_failed",
+                                            "out_of_stock",
+                                            "pricing_error",
+                                            "duplicate_order",
+                                            "other"
+                                        ],
+                                        "example": "customer_cancelled"
+                                    },
+                                    "reason_note": {
+                                        "type": "string",
+                                        "example": "El cliente ya no necesita el pedido.",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Operación cancelada exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Operación cancelada exitosamente."
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/CommercialOperationResource"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Sin permisos"
+                    },
+                    "404": {
+                        "description": "Operación no encontrada"
+                    },
+                    "422": {
+                        "description": "Error de validación"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/store/customers/{customerId}/addresses": {
             "get": {
                 "tags": [

--- a/tests/Feature/Api/V1/Store/CommercialOperationCancelTest.php
+++ b/tests/Feature/Api/V1/Store/CommercialOperationCancelTest.php
@@ -1,0 +1,500 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Category;
+use App\Models\CommercialOperation;
+use App\Models\CommercialOperationEvent;
+use App\Models\Customer;
+use App\Models\Feature;
+use App\Models\OperationItem;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_USER', 'guard_name' => 'web']);
+    Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'BACKOFFICE_USER', 'guard_name' => 'web']);
+
+    Permission::firstOrCreate(['name' => 'orders.edit', 'guard_name' => 'web']);
+
+    $this->store = Store::factory()->create();
+    $this->plan = Plan::factory()->create();
+    $this->store->plan_id = $this->plan->id;
+    $this->store->save();
+
+    $posFeature = Feature::firstOrCreate(['code' => 'pos', 'name' => 'Punto de Venta']);
+    $this->plan->features()->syncWithoutDetaching([$posFeature->id => ['limit_value' => null]]);
+
+    $this->category = Category::factory()->create(['store_id' => $this->store->id]);
+    $this->customer = Customer::factory()->create(['store_id' => $this->store->id]);
+
+    $this->product = Product::factory()->create([
+        'store_id' => $this->store->id,
+        'category_id' => $this->category->id,
+        'stock' => 10,
+        'stock_reserved' => 5,
+        'price' => 100.00,
+    ]);
+});
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function makeAuthUserCancel(Store $store, string $role = 'STORE_ADMIN', array $permissions = []): User
+{
+    $user = User::factory()->create(['store_id' => $store->id]);
+    $user->assignRole($role);
+
+    foreach ($permissions as $perm) {
+        $user->givePermissionTo($perm);
+    }
+
+    return $user;
+}
+
+function makeOrderForCancel(Store $store, array $attributes = []): CommercialOperation
+{
+    $user = User::factory()->create(['store_id' => $store->id]);
+
+    return CommercialOperation::factory()->create(array_merge([
+        'store_id' => $store->id,
+        'user_id' => $user->id,
+        'customer_id' => Customer::factory()->create(['store_id' => $store->id])->id,
+        'type' => 'order',
+        'status' => 'open',
+        'requested_delivery_date' => now()->addDays(5)->format('Y-m-d'),
+    ], $attributes));
+}
+
+function cancelOp(User $user, string $operationId, array $data = []): \Illuminate\Testing\TestResponse
+{
+    $default = [
+        'reason_code' => 'customer_cancelled',
+    ];
+
+    return test()->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/store/operations/{$operationId}/cancel", array_merge($default, $data));
+}
+
+// ─── CANCEL-008: Migration columns ─────────────────────────────────────
+
+describe('CANCEL-008: Migration — Events table columns', function () {
+    it('adds previous_status, new_status, reason_code, and reason_note columns to events table', function () {
+        expect(Schema::hasColumn('commercial_operation_events', 'previous_status'))->toBeTrue();
+        expect(Schema::hasColumn('commercial_operation_events', 'new_status'))->toBeTrue();
+        expect(Schema::hasColumn('commercial_operation_events', 'reason_code'))->toBeTrue();
+        expect(Schema::hasColumn('commercial_operation_events', 'reason_note'))->toBeTrue();
+    });
+
+    it('allows existing reschedule events to coexist with new nullable columns', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        // Create a reschedule event (existing pattern)
+        $event = CommercialOperationEvent::create([
+            'store_id' => $this->store->id,
+            'operation_id' => $order->id,
+            'event_type' => 'delivery_date_changed',
+            'previous_date' => '2026-07-20',
+            'new_date' => '2026-07-25',
+            'reason' => 'customer_requested_reschedule',
+            'observation' => null,
+            'user_id' => $user->id,
+        ]);
+
+        // Refresh from DB to see actual stored values
+        $event->refresh();
+
+        expect($event->previous_status)->toBeNull();
+        expect($event->new_status)->toBeNull();
+        expect($event->reason_code)->toBeNull();
+        expect($event->reason_note)->toBeNull();
+        // Existing columns still work
+        expect($event->previous_date->format('Y-m-d'))->toBe('2026-07-20');
+        expect($event->new_date->format('Y-m-d'))->toBe('2026-07-25');
+        expect($event->reason)->toBe('customer_requested_reschedule');
+    });
+});
+
+// ─── CANCEL-009: Model updates ─────────────────────────────────────────
+
+describe('CANCEL-009: Model updates', function () {
+    it('accepts new cancellation fields through fillable without mass-assignment errors', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        $event = CommercialOperationEvent::create([
+            'store_id' => $this->store->id,
+            'operation_id' => $order->id,
+            'event_type' => 'order_cancelled',
+            'previous_date' => '2026-07-25',
+            'new_date' => null,
+            'reason' => 'customer_cancelled',
+            'observation' => null,
+            'user_id' => $user->id,
+            'previous_status' => 'open',
+            'new_status' => 'cancelled',
+            'reason_code' => 'customer_cancelled',
+            'reason_note' => null,
+        ]);
+
+        expect($event->previous_status)->toBe('open');
+        expect($event->new_status)->toBe('cancelled');
+        expect($event->reason_code)->toBe('customer_cancelled');
+        expect($event->reason_note)->toBeNull();
+    });
+});
+
+// ─── CANCEL-001 + CANCEL-007: Successful cancel endpoint ───────────────
+
+describe('PUT /api/v1/store/operations/{operation}/cancel', function () {
+    it('returns 200 and cancels order with future delivery, releasing stock_reserved', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store, [
+            'requested_delivery_date' => now()->addDays(3)->format('Y-m-d'),
+        ]);
+
+        $product = $this->product;
+        $product->update(['stock_reserved' => 5]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $order->id,
+            'product_id' => $product->id,
+            'product_name' => $product->name,
+            'quantity' => 2,
+            'price' => 100.00,
+            'subtotal' => 200.00,
+        ]);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'customer_cancelled',
+            'reason_note' => 'Ya no lo necesita',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'success')
+            ->assertJsonPath('data.status', 'cancelled')
+            ->assertJsonPath('data.id', $order->id);
+
+        // Verify stock_reserved released (5 - 2 = 3)
+        $product->refresh();
+        expect($product->stock_reserved)->toBe(3);
+
+        // Verify event created
+        $this->assertDatabaseHas('commercial_operation_events', [
+            'operation_id' => $order->id,
+            'event_type' => 'order_cancelled',
+            'store_id' => $this->store->id,
+            'previous_status' => 'open',
+            'new_status' => 'cancelled',
+            'reason_code' => 'customer_cancelled',
+        ]);
+
+        // Verify operation status
+        $order->refresh();
+        expect($order->status)->toBe('cancelled');
+    });
+
+    it('returns 200 and cancels same-day order without modifying stock_reserved', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store, [
+            'requested_delivery_date' => now()->format('Y-m-d'),
+        ]);
+
+        $product = $this->product;
+        $product->update(['stock_reserved' => 5]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $order->id,
+            'product_id' => $product->id,
+            'product_name' => $product->name,
+            'quantity' => 2,
+            'price' => 100.00,
+            'subtotal' => 200.00,
+        ]);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'customer_cancelled',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', 'cancelled');
+
+        // Stock reserved must NOT change for same-day delivery
+        $product->refresh();
+        expect($product->stock_reserved)->toBe(5);
+    });
+
+    it('returns 403 when user lacks orders.edit permission', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', []);
+        $order = makeOrderForCancel($this->store);
+
+        $response = cancelOp($user, $order->id);
+
+        $response->assertForbidden();
+    });
+
+    it('returns 404 when operation belongs to different store', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+
+        $otherStore = Store::factory()->create();
+        $otherPlan = Plan::factory()->create();
+        $otherStore->plan_id = $otherPlan->id;
+        $otherStore->save();
+        $posFeature = Feature::where('code', 'pos')->first();
+        $otherPlan->features()->syncWithoutDetaching([$posFeature->id => ['limit_value' => null]]);
+
+        $otherOrder = makeOrderForCancel($otherStore);
+
+        $response = cancelOp($user, $otherOrder->id);
+
+        $response->assertNotFound();
+    });
+
+    it('returns 200 with correct success response shape', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'customer_cancelled',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data',
+                'errors',
+            ])
+            ->assertJsonPath('status', 'success')
+            ->assertJsonPath('message', 'Operación cancelada exitosamente.')
+            ->assertJsonPath('errors', null);
+    });
+});
+
+// ─── CANCEL-002: Request validation ────────────────────────────────────
+
+describe('CANCEL-002: Request validation', function () {
+    it('returns 422 when reason_code is missing', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        $response = test()->actingAs($user, 'sanctum')
+            ->putJson("/api/v1/store/operations/{$order->id}/cancel", []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['reason_code']);
+    });
+
+    it('returns 422 when reason_code is invalid', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'invalid_reason',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['reason_code']);
+    });
+
+    it('returns 422 when reason_code is other and reason_note is missing', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'other',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['reason_note']);
+    });
+
+    it('accepts valid reason_codes: customer_cancelled, payment_failed, out_of_stock, pricing_error, duplicate_order, other', function (string $code) {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        $data = ['reason_code' => $code];
+        if ($code === 'other') {
+            $data['reason_note'] = 'Razón detallada aquí';
+        }
+
+        $response = cancelOp($user, $order->id, $data);
+
+        $response->assertOk();
+    })->with([
+        'customer_cancelled',
+        'payment_failed',
+        'out_of_stock',
+        'pricing_error',
+        'duplicate_order',
+        'other',
+    ]);
+});
+
+// ─── CANCEL-003: Business rule validation ──────────────────────────────
+
+describe('CANCEL-003: Business rule validation', function () {
+    it('returns 422 when operation type is sale', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+
+        $sale = CommercialOperation::factory()->create([
+            'store_id' => $this->store->id,
+            'user_id' => User::factory()->create(['store_id' => $this->store->id])->id,
+            'type' => 'sale',
+            'status' => 'confirmed',
+        ]);
+
+        $response = cancelOp($user, $sale->id);
+
+        $response->assertStatus(422);
+    });
+
+    it('returns 422 when operation status is confirmed (not open)', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+
+        $order = CommercialOperation::factory()->create([
+            'store_id' => $this->store->id,
+            'user_id' => User::factory()->create(['store_id' => $this->store->id])->id,
+            'customer_id' => $this->customer->id,
+            'type' => 'order',
+            'status' => 'confirmed',
+            'requested_delivery_date' => now()->addDays(5)->format('Y-m-d'),
+        ]);
+
+        $response = cancelOp($user, $order->id);
+
+        $response->assertStatus(422);
+    });
+
+    it('returns 422 when operation is already cancelled', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+
+        $order = CommercialOperation::factory()->create([
+            'store_id' => $this->store->id,
+            'user_id' => User::factory()->create(['store_id' => $this->store->id])->id,
+            'customer_id' => $this->customer->id,
+            'type' => 'order',
+            'status' => 'cancelled',
+            'requested_delivery_date' => now()->addDays(5)->format('Y-m-d'),
+        ]);
+
+        $response = cancelOp($user, $order->id);
+
+        $response->assertStatus(422);
+    });
+});
+
+// ─── CANCEL-004: Event creation details ────────────────────────────────
+
+describe('CANCEL-004: Event creation details', function () {
+    it('records cancellation event with correct fields', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store, [
+            'requested_delivery_date' => '2026-07-25',
+        ]);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'customer_cancelled',
+        ]);
+
+        $response->assertOk();
+
+        $event = CommercialOperationEvent::where('operation_id', $order->id)->first();
+
+        expect($event)->not->toBeNull()
+            ->and($event->event_type)->toBe('order_cancelled')
+            ->and($event->previous_status)->toBe('open')
+            ->and($event->new_status)->toBe('cancelled')
+            ->and($event->reason_code)->toBe('customer_cancelled')
+            ->and($event->previous_date->format('Y-m-d'))->toBe('2026-07-25')
+            ->and($event->new_date)->toBeNull()
+            ->and($event->store_id)->toBe($this->store->id)
+            ->and($event->user_id)->toBe($user->id);
+    });
+});
+
+// ─── CANCEL-005: Stock release — multiple items ────────────────────────
+
+describe('CANCEL-005: Stock release — multiple items', function () {
+    it('releases reserved stock proportionally for all items on future delivery cancel', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store, [
+            'requested_delivery_date' => now()->addDays(3)->format('Y-m-d'),
+        ]);
+
+        $productA = $this->product;
+        $productA->update(['stock_reserved' => 5]);
+
+        $productB = Product::factory()->create([
+            'store_id' => $this->store->id,
+            'category_id' => $this->category->id,
+            'stock' => 20,
+            'stock_reserved' => 8,
+            'price' => 50.00,
+        ]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $order->id,
+            'product_id' => $productA->id,
+            'product_name' => $productA->name,
+            'quantity' => 3,
+            'price' => 100.00,
+            'subtotal' => 300.00,
+        ]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $order->id,
+            'product_id' => $productB->id,
+            'product_name' => $productB->name,
+            'quantity' => 2,
+            'price' => 50.00,
+            'subtotal' => 100.00,
+        ]);
+
+        $response = cancelOp($user, $order->id, [
+            'reason_code' => 'customer_cancelled',
+        ]);
+
+        $response->assertOk();
+
+        $productA->refresh();
+        $productB->refresh();
+
+        expect($productA->stock_reserved)->toBe(2);  // 5 - 3
+        expect($productB->stock_reserved)->toBe(6);  // 8 - 2
+    });
+});
+
+// ─── CANCEL-006: Concurrent cancel protection ──────────────────────────
+
+describe('CANCEL-006: Transaction safety', function () {
+    it('rejects a second cancel on an already cancelled operation', function () {
+        $user = makeAuthUserCancel($this->store, 'STORE_ADMIN', ['orders.edit']);
+        $order = makeOrderForCancel($this->store);
+
+        // First cancel — should succeed
+        $first = cancelOp($user, $order->id, [
+            'reason_code' => 'customer_cancelled',
+        ]);
+        $first->assertOk();
+
+        // Second cancel — should be rejected (status already changed)
+        $second = cancelOp($user, $order->id, [
+            'reason_code' => 'duplicate_order',
+        ]);
+        $second->assertStatus(422);
+    });
+});

--- a/tests/Unit/Services/CommercialOperationCancelServiceTest.php
+++ b/tests/Unit/Services/CommercialOperationCancelServiceTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Category;
+use App\Models\CommercialOperation;
+use App\Models\Customer;
+use App\Models\OperationItem;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\CommercialOperationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+
+uses(Tests\TestCase::class);
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->store = Store::factory()->create();
+    $this->user = User::factory()->create(['store_id' => $this->store->id]);
+    $this->customer = Customer::factory()->create(['store_id' => $this->store->id]);
+    $this->category = Category::factory()->create(['store_id' => $this->store->id]);
+    $this->service = new CommercialOperationService();
+});
+
+function makeOrderForCancelUnit(Store $store, array $attributes = []): CommercialOperation
+{
+    return CommercialOperation::factory()->create(array_merge([
+        'store_id' => $store->id,
+        'user_id' => User::factory()->create(['store_id' => $store->id])->id,
+        'customer_id' => Customer::factory()->create(['store_id' => $store->id])->id,
+        'type' => 'order',
+        'status' => 'open',
+        'requested_delivery_date' => now()->addDays(5)->format('Y-m-d'),
+    ], $attributes));
+}
+
+describe('cancel() — business rule validation', function () {
+    it('throws ValidationException when operation type is not order', function () {
+        $operation = CommercialOperation::factory()->create([
+            'store_id' => $this->store->id,
+            'user_id' => $this->user->id,
+            'type' => 'sale',
+            'status' => 'confirmed',
+        ]);
+
+        expect(fn () => $this->service->cancel(
+            $operation,
+            'customer_cancelled',
+            null,
+            $this->user
+        ))->toThrow(ValidationException::class);
+    });
+
+    it('throws ValidationException when status is not open', function () {
+        $operation = makeOrderForCancelUnit($this->store, ['status' => 'confirmed']);
+
+        expect(fn () => $this->service->cancel(
+            $operation,
+            'customer_cancelled',
+            null,
+            $this->user
+        ))->toThrow(ValidationException::class);
+    });
+
+    it('throws ValidationException when status is cancelled', function () {
+        $operation = makeOrderForCancelUnit($this->store, ['status' => 'cancelled']);
+
+        expect(fn () => $this->service->cancel(
+            $operation,
+            'customer_cancelled',
+            null,
+            $this->user
+        ))->toThrow(ValidationException::class);
+    });
+});
+
+describe('cancel() — happy path with stock release', function () {
+    it('cancels order, releases stock_reserved for future delivery, and creates event', function () {
+        $operation = makeOrderForCancelUnit($this->store, [
+            'requested_delivery_date' => now()->addDays(3)->format('Y-m-d'),
+        ]);
+
+        $product = Product::factory()->create([
+            'store_id' => $this->store->id,
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'stock_reserved' => 5,
+            'price' => 100.00,
+        ]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $operation->id,
+            'product_id' => $product->id,
+            'product_name' => $product->name,
+            'quantity' => 2,
+            'price' => 100.00,
+            'subtotal' => 200.00,
+        ]);
+
+        $result = $this->service->cancel(
+            $operation,
+            'customer_cancelled',
+            'Ya no lo necesita',
+            $this->user
+        );
+
+        expect($result->status)->toBe('cancelled');
+
+        $product->refresh();
+        expect($product->stock_reserved)->toBe(3); // 5 - 2
+
+        $this->assertDatabaseHas('commercial_operation_events', [
+            'operation_id' => $operation->id,
+            'event_type' => 'order_cancelled',
+            'previous_status' => 'open',
+            'new_status' => 'cancelled',
+            'reason_code' => 'customer_cancelled',
+            'store_id' => $this->store->id,
+        ]);
+
+        $event = \App\Models\CommercialOperationEvent::where('operation_id', $operation->id)->first();
+        expect($event)->not->toBeNull()
+            ->and($event->reason_note)->toBe('Ya no lo necesita');
+    });
+
+    it('cancels same-day order without modifying stock_reserved', function () {
+        $operation = makeOrderForCancelUnit($this->store, [
+            'requested_delivery_date' => now()->format('Y-m-d'),
+        ]);
+
+        $product = Product::factory()->create([
+            'store_id' => $this->store->id,
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'stock_reserved' => 5,
+            'price' => 100.00,
+        ]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $operation->id,
+            'product_id' => $product->id,
+            'product_name' => $product->name,
+            'quantity' => 2,
+            'price' => 100.00,
+            'subtotal' => 200.00,
+        ]);
+
+        $result = $this->service->cancel(
+            $operation,
+            'customer_cancelled',
+            null,
+            $this->user
+        );
+
+        expect($result->status)->toBe('cancelled');
+
+        $product->refresh();
+        expect($product->stock_reserved)->toBe(5); // unchanged — same-day delivery
+    });
+});
+
+describe('cancel() — stock underflow guard', function () {
+    it('prevents negative stock_reserved when release exceeds reserved', function () {
+        $operation = makeOrderForCancelUnit($this->store, [
+            'requested_delivery_date' => now()->addDays(3)->format('Y-m-d'),
+        ]);
+
+        $product = Product::factory()->create([
+            'store_id' => $this->store->id,
+            'category_id' => $this->category->id,
+            'stock' => 10,
+            'stock_reserved' => 2,
+            'price' => 100.00,
+        ]);
+
+        OperationItem::factory()->create([
+            'operation_id' => $operation->id,
+            'product_id' => $product->id,
+            'product_name' => $product->name,
+            'quantity' => 5,
+            'price' => 100.00,
+            'subtotal' => 500.00,
+        ]);
+
+        $result = $this->service->cancel(
+            $operation,
+            'out_of_stock',
+            null,
+            $this->user
+        );
+
+        expect($result->status)->toBe('cancelled');
+
+        $product->refresh();
+        expect($product->stock_reserved)->toBe(0); // max(0, 2-5) = 0
+    });
+});
+
+describe('cancel() — event fields', function () {
+    it('sets previous_date from operation requested_delivery_date and new_date to null', function () {
+        $operation = makeOrderForCancelUnit($this->store, [
+            'requested_delivery_date' => '2026-07-25',
+        ]);
+
+        $result = $this->service->cancel(
+            $operation,
+            'duplicate_order',
+            null,
+            $this->user
+        );
+
+        $event = \App\Models\CommercialOperationEvent::where('operation_id', $operation->id)->first();
+
+        expect($event)->not->toBeNull()
+            ->and($event->previous_date->format('Y-m-d'))->toBe('2026-07-25')
+            ->and($event->new_date)->toBeNull()
+            ->and($event->reason_code)->toBe('duplicate_order')
+            ->and($event->reason_note)->toBeNull();
+    });
+
+    it('stores reason_note when provided', function () {
+        $operation = makeOrderForCancelUnit($this->store, [
+            'requested_delivery_date' => now()->addDays(3)->format('Y-m-d'),
+        ]);
+
+        $result = $this->service->cancel(
+            $operation,
+            'other',
+            'Motivo detallado de cancelación',
+            $this->user
+        );
+
+        $event = \App\Models\CommercialOperationEvent::where('operation_id', $operation->id)->first();
+
+        expect($event->reason_code)->toBe('other');
+        expect($event->reason_note)->toBe('Motivo detallado de cancelación');
+    });
+});


### PR DESCRIPTION
- Added CancelOrderRequest to handle validation for cancel order requests.
- Implemented cancel method in CommercialOperationController to allow cancellation of open orders.
- Created CommercialOperationService::cancel method to encapsulate cancellation logic and event creation.
- Updated CommercialOperationEvent model to include new fields for cancellation tracking.
- Added migration to introduce new columns in the commercial_operation_events table.
- Defined API route for canceling orders in routes/api.php.
- Enhanced API documentation to include cancel order endpoint.
- Developed comprehensive tests for cancel order functionality, covering various scenarios and validations.