### PR TITLE
feat: Add orders management functionality

### DIFF
--- a/app/Http/Controllers/Api/V1/Store/OrderController.php
+++ b/app/Http/Controllers/Api/V1/Store/OrderController.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Store;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Store\ListOrdersRequest;
+use App\Http\Resources\CommercialOperationListResource;
+use App\Http\Resources\CommercialOperationResource;
+use App\Models\CommercialOperation;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OrderController extends Controller
+{
+    /**
+     * Listado paginado de pedidos de la tienda.
+     *
+     * @OA\Get(
+     *   path="/store/orders",
+     *   summary="Listar pedidos de la tienda",
+     *   tags={"Store - Pedidos"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="date", in="query", @OA\Schema(type="string", format="date"), description="Filtrar por fecha de entrega (YYYY-MM-DD). Ignora date_from y date_to."),
+     *   @OA\Parameter(name="date_from", in="query", @OA\Schema(type="string", format="date"), description="Filtrar desde fecha (YYYY-MM-DD)"),
+     *   @OA\Parameter(name="date_to", in="query", @OA\Schema(type="string", format="date"), description="Filtrar hasta fecha (YYYY-MM-DD)"),
+     *   @OA\Parameter(name="status", in="query", @OA\Schema(type="string", enum={"open", "confirmed", "cancelled", "closed"}), description="Filtrar por estado. Default: activos (open, confirmed)"),
+     *   @OA\Parameter(name="operation_number", in="query", @OA\Schema(type="string"), description="Búsqueda por número de pedido (parcial)"),
+     *   @OA\Parameter(name="customer_name", in="query", @OA\Schema(type="string"), description="Búsqueda por nombre de cliente"),
+     *   @OA\Parameter(name="locality", in="query", @OA\Schema(type="string"), description="Búsqueda por localidad del domicilio de entrega"),
+     *   @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", default=20), description="Items por página"),
+     *   @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", default=1), description="Número de página"),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Pedidos obtenidos exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="string", example="Pedidos obtenidos exitosamente."),
+     *       @OA\Property(property="data", type="object",
+     *         @OA\Property(property="items", type="array", @OA\Items(ref="#/components/schemas/CommercialOperationListResource")),
+     *         @OA\Property(property="total", type="integer", example=25),
+     *         @OA\Property(property="per_page", type="integer", example=20),
+     *         @OA\Property(property="current_page", type="integer", example=1),
+     *         @OA\Property(property="last_page", type="integer", example=2)
+     *       ),
+     *       @OA\Property(property="errors", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=401, description="No autenticado"),
+     *   @OA\Response(response=403, description="Sin permisos")
+     * )
+     */
+    public function index(ListOrdersRequest $request): JsonResponse
+    {
+        $storeId = $request->user()->store_id;
+
+        $query = CommercialOperation::forStore($storeId)
+            ->byType('order')
+            ->with(['customer.addresses.locality', 'items', 'payments']);
+
+        // Status: default solo activos
+        if ($request->filled('status')) {
+            $query->byStatus($request->status);
+        } else {
+            $query->whereIn('status', ['open', 'confirmed']);
+        }
+
+        // Filtros de fecha
+        if ($request->filled('date')) {
+            $query->whereDate('requested_delivery_date', $request->date);
+        } else {
+            if ($request->filled('date_from')) {
+                $query->whereDate('requested_delivery_date', '>=', $request->date_from);
+            }
+
+            if ($request->filled('date_to')) {
+                $query->whereDate('requested_delivery_date', '<=', $request->date_to);
+            }
+        }
+
+        // Búsqueda por número de pedido
+        if ($request->filled('operation_number')) {
+            $query->where('operation_number', 'like', '%'.$request->operation_number.'%');
+        }
+
+        // Búsqueda por nombre de cliente
+        if ($request->filled('customer_name')) {
+            $query->whereHas('customer', function ($q) use ($request) {
+                $q->where('display_name', 'like', '%'.$request->customer_name.'%');
+            });
+        }
+
+        // Búsqueda por localidad del domicilio de entrega
+        if ($request->filled('locality')) {
+            $query->whereHas('customer.addresses', function ($q) use ($request) {
+                $q->where('is_main', true)
+                    ->whereHas('locality', function ($q2) use ($request) {
+                        $q2->where('name', 'like', '%'.$request->locality.'%');
+                    });
+            });
+        }
+
+        $query->orderBy('requested_delivery_date', 'asc')
+            ->orderBy('operation_number', 'asc');
+
+        $query->withSum('payments', 'amount');
+
+        $operations = $query->paginate($request->per_page ?? 20);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Pedidos obtenidos exitosamente.',
+            'data' => [
+                'items' => CommercialOperationListResource::collection($operations->items()),
+                'total' => $operations->total(),
+                'per_page' => $operations->perPage(),
+                'current_page' => $operations->currentPage(),
+                'last_page' => $operations->lastPage(),
+            ],
+            'errors' => null,
+        ]);
+    }
+
+    /**
+     * Detalle completo de un pedido.
+     *
+     * @OA\Get(
+     *   path="/store/orders/{id}",
+     *   summary="Ver detalle de un pedido",
+     *   tags={"Store - Pedidos"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Pedido obtenido exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="string", example="Pedido obtenido exitosamente."),
+     *       @OA\Property(property="data", ref="#/components/schemas/CommercialOperationResource"),
+     *       @OA\Property(property="errors", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=401, description="No autenticado"),
+     *   @OA\Response(response=403, description="Sin permisos"),
+     *   @OA\Response(response=404, description="Pedido no encontrado")
+     * )
+     */
+    public function show(Request $request, string $id): JsonResponse
+    {
+        $storeId = $request->user()->store_id;
+
+        $operation = CommercialOperation::query()
+            ->forStore($storeId)
+            ->with([
+                'customer.addresses.locality',
+                'items.product',
+                'payments.storePaymentMethod.paymentMethod',
+                'events.user',
+                'user',
+            ])
+            ->withSum('payments', 'amount')
+            ->find($id);
+
+        if (! $operation) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Pedido no encontrado.',
+                'data' => null,
+                'errors' => ['id' => ['El pedido no existe o no pertenece a tu tienda.']],
+            ], 404);
+        }
+
+        if ($operation->type !== 'order') {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Pedido no encontrado.',
+                'data' => null,
+                'errors' => ['id' => ['El recurso solicitado no es un pedido.']],
+            ], 404);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Pedido obtenido exitosamente.',
+            'data' => CommercialOperationResource::make($operation),
+            'errors' => null,
+        ], 200);
+    }
+}

--- a/app/Http/Requests/Api/V1/Store/ListOrdersRequest.php
+++ b/app/Http/Requests/Api/V1/Store/ListOrdersRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Store;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rule;
+
+class ListOrdersRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date' => ['nullable', 'date_format:Y-m-d'],
+            'date_from' => ['nullable', 'date_format:Y-m-d'],
+            'date_to' => ['nullable', 'date_format:Y-m-d'],
+            'status' => ['nullable', 'string', Rule::in(['open', 'confirmed', 'cancelled', 'closed'])],
+            'operation_number' => ['nullable', 'string', 'max:20'],
+            'customer_name' => ['nullable', 'string', 'max:255'],
+            'locality' => ['nullable', 'string', 'max:255'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'date.date_format' => 'La fecha debe tener el formato YYYY-MM-DD.',
+            'date_from.date_format' => 'La fecha de inicio debe tener el formato YYYY-MM-DD.',
+            'date_to.date_format' => 'La fecha de fin debe tener el formato YYYY-MM-DD.',
+            'status.in' => 'El estado debe ser: open, confirmed, cancelled o closed.',
+            'operation_number.max' => 'El número de operación no puede exceder 20 caracteres.',
+            'customer_name.max' => 'El nombre del cliente no puede exceder 255 caracteres.',
+            'locality.max' => 'La localidad no puede exceder 255 caracteres.',
+            'per_page.integer' => 'La cantidad de items por página debe ser un número entero.',
+            'per_page.min' => 'La cantidad de items por página debe ser al menos 1.',
+            'per_page.max' => 'La cantidad de items por página no puede exceder 100.',
+            'page.integer' => 'El número de página debe ser un número entero.',
+            'page.min' => 'El número de página debe ser al menos 1.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Resources/CommercialOperationEventResource.php
+++ b/app/Http/Resources/CommercialOperationEventResource.php
@@ -5,6 +5,35 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *   schema="CommercialOperationEventResource",
+ *   type="object",
+ *   title="CommercialOperationEventResource",
+ *
+ *   @OA\Property(property="id", type="string", format="uuid"),
+ *   @OA\Property(property="event_type", type="string"),
+ *   @OA\Property(property="previous_status", type="string", nullable=true),
+ *   @OA\Property(property="new_status", type="string", nullable=true),
+ *   @OA\Property(property="reason", type="string"),
+ *   @OA\Property(property="reason_code", type="string", nullable=true),
+ *   @OA\Property(property="reason_note", type="string", nullable=true),
+ *   @OA\Property(property="observation", type="string", nullable=true),
+ *   @OA\Property(property="old_values", type="object", nullable=true,
+ *     @OA\Property(property="status", type="string", nullable=true),
+ *     @OA\Property(property="date", type="string", format="date", nullable=true)
+ *   ),
+ *   @OA\Property(property="new_values", type="object", nullable=true,
+ *     @OA\Property(property="status", type="string", nullable=true),
+ *     @OA\Property(property="date", type="string", format="date", nullable=true)
+ *   ),
+ *   @OA\Property(property="user", type="object", nullable=true,
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="name", type="string")
+ *   ),
+ *   @OA\Property(property="created_at", type="string", format="date-time")
+ * )
+ */
 class CommercialOperationEventResource extends JsonResource
 {
     public function toArray(Request $request): array
@@ -20,11 +49,19 @@ class CommercialOperationEventResource extends JsonResource
             'reason_code' => $this->reason_code,
             'reason_note' => $this->reason_note,
             'observation' => $this->observation,
+            'old_values' => [
+                'status' => $this->previous_status,
+                'date' => $this->previous_date?->format('Y-m-d'),
+            ],
+            'new_values' => [
+                'status' => $this->new_status,
+                'date' => $this->new_date?->format('Y-m-d'),
+            ],
             'user' => $this->whenLoaded('user', fn () => [
                 'id' => $this->user_id,
                 'name' => $this->user?->name,
             ]),
-            'created_at' => $this->created_at?->toIso8601String(),
+            'created_at' => $this->created_at?->format('Y-m-d H:i:s'),
         ];
     }
 }

--- a/app/Http/Resources/CommercialOperationListResource.php
+++ b/app/Http/Resources/CommercialOperationListResource.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @OA\Schema(
+ *   schema="CommercialOperationListResource",
+ *   type="object",
+ *   title="CommercialOperationListResource",
+ *
+ *   @OA\Property(property="id", type="string", format="uuid"),
+ *   @OA\Property(property="operation_number", type="string"),
+ *   @OA\Property(property="type", type="string"),
+ *   @OA\Property(property="status", type="string"),
+ *   @OA\Property(property="requested_delivery_date", type="string", format="date", nullable=true),
+ *   @OA\Property(property="delivery_time_from", type="string", nullable=true, example=null),
+ *   @OA\Property(property="delivery_time_to", type="string", nullable=true, example=null),
+ *   @OA\Property(property="total", type="number", format="float"),
+ *   @OA\Property(property="paid_amount", type="number", format="float"),
+ *   @OA\Property(property="pending_amount", type="number", format="float"),
+ *   @OA\Property(property="items_count", type="integer"),
+ *   @OA\Property(property="customer", type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="name", type="string"),
+ *     @OA\Property(property="phone", type="string", nullable=true)
+ *   ),
+ *   @OA\Property(property="delivery_address", type="object", nullable=true,
+ *     @OA\Property(property="locality", type="string", nullable=true),
+ *     @OA\Property(property="street", type="string", nullable=true),
+ *     @OA\Property(property="full_address", type="string", nullable=true)
+ *   ),
+ *   @OA\Property(property="branch_id", type="string", format="uuid", nullable=true)
+ * )
+ */
+class CommercialOperationListResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'operation_number' => $this->operation_number,
+            'type' => $this->type,
+            'status' => $this->status,
+            'requested_delivery_date' => $this->requested_delivery_date?->format('Y-m-d'),
+            'delivery_time_from' => null,
+            'delivery_time_to' => null,
+            'total' => (float) $this->total,
+            'paid_amount' => (float) ($this->payments_sum_amount ?? 0),
+            'pending_amount' => (float) ($this->total - ($this->payments_sum_amount ?? 0)),
+            'items_count' => $this->whenLoaded('items', fn () => $this->items->count(), 0),
+            'customer' => $this->whenLoaded('customer', fn () => [
+                'id' => $this->customer->id,
+                'name' => $this->customer->display_name,
+                'phone' => null,
+            ]),
+            'delivery_address' => $this->getDeliveryAddress(),
+            'branch_id' => $this->branch_id,
+        ];
+    }
+
+    private function getDeliveryAddress(): ?array
+    {
+        $address = $this->delivery_address;
+
+        if (! $address) {
+            return null;
+        }
+
+        $street = $address->street ?? '';
+        $number = $address->number ?? '';
+        $fullAddress = trim($street.' '.$number);
+
+        return [
+            'locality' => $address->locality?->name,
+            'street' => $address->street,
+            'full_address' => $fullAddress ?: null,
+        ];
+    }
+}

--- a/app/Http/Resources/CommercialOperationResource.php
+++ b/app/Http/Resources/CommercialOperationResource.php
@@ -10,26 +10,46 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *   schema="CommercialOperationResource",
  *   type="object",
  *   title="CommercialOperationResource",
+ *
  *   @OA\Property(property="id", type="string", format="uuid"),
  *   @OA\Property(property="operation_number", type="string"),
  *   @OA\Property(property="type", type="string"),
  *   @OA\Property(property="status", type="string"),
- *   @OA\Property(property="customer", type="object", nullable=true),
- *   @OA\Property(property="user", type="object",
- *     @OA\Property(property="id", type="string", format="uuid"),
- *     @OA\Property(property="name", type="string")
- *   ),
- *   @OA\Property(property="branch_id", type="string", format="uuid", nullable=true),
+ *   @OA\Property(property="requested_delivery_date", type="string", format="date", nullable=true),
+ *   @OA\Property(property="delivery_time_from", type="string", nullable=true, example=null),
+ *   @OA\Property(property="delivery_time_to", type="string", nullable=true, example=null),
  *   @OA\Property(property="subtotal", type="number", format="float"),
  *   @OA\Property(property="tax", type="number", format="float"),
  *   @OA\Property(property="discount", type="number", format="float"),
  *   @OA\Property(property="total", type="number", format="float"),
- *   @OA\Property(property="delivery_date", type="string", format="date", nullable=true),
+ *   @OA\Property(property="paid_amount", type="number", format="float"),
+ *   @OA\Property(property="pending_amount", type="number", format="float"),
  *   @OA\Property(property="completed_at", type="string", format="date-time", nullable=true),
+ *   @OA\Property(property="created_at", type="string", format="date-time"),
+ *   @OA\Property(property="updated_at", type="string", format="date-time"),
+ *   @OA\Property(property="branch_id", type="string", format="uuid", nullable=true),
+ *   @OA\Property(property="created_by", type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="name", type="string")
+ *   ),
+ *   @OA\Property(property="customer", type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="name", type="string"),
+ *     @OA\Property(property="phone", type="string", nullable=true),
+ *     @OA\Property(property="email", type="string", nullable=true)
+ *   ),
+ *   @OA\Property(property="delivery_address", type="object", nullable=true,
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="street", type="string", nullable=true),
+ *     @OA\Property(property="number", type="string", nullable=true),
+ *     @OA\Property(property="locality", type="string", nullable=true),
+ *     @OA\Property(property="province", type="string", nullable=true),
+ *     @OA\Property(property="notes", type="string", nullable=true),
+ *     @OA\Property(property="full_address", type="string", nullable=true)
+ *   ),
  *   @OA\Property(property="items", type="array", @OA\Items(ref="#/components/schemas/OperationItemResource")),
  *   @OA\Property(property="payments", type="array", @OA\Items(ref="#/components/schemas/OperationPaymentResource")),
- *   @OA\Property(property="created_at", type="string", format="date-time"),
- *   @OA\Property(property="updated_at", type="string", format="date-time")
+ *   @OA\Property(property="events", type="array", @OA\Items(ref="#/components/schemas/CommercialOperationEventResource"))
  * )
  */
 class CommercialOperationResource extends JsonResource
@@ -41,23 +61,56 @@ class CommercialOperationResource extends JsonResource
             'operation_number' => $this->operation_number,
             'type' => $this->type,
             'status' => $this->status,
-            'customer' => CustomerResource::make($this->whenLoaded('customer')),
-            'user' => [
-                'id' => $this->user_id,
-                'name' => $this->user?->name,
-            ],
-            'branch_id' => $this->branch_id,
+            'requested_delivery_date' => $this->requested_delivery_date?->format('Y-m-d'),
+            'delivery_time_from' => null,
+            'delivery_time_to' => null,
             'subtotal' => (float) $this->subtotal,
             'tax' => (float) $this->tax,
             'discount' => (float) $this->discount,
             'total' => (float) $this->total,
-            'delivery_date' => $this->requested_delivery_date?->format('Y-m-d'),
+            'paid_amount' => (float) ($this->payments_sum_amount ?? 0),
+            'pending_amount' => (float) ($this->total - ($this->payments_sum_amount ?? 0)),
             'completed_at' => $this->completed_at?->format('Y-m-d H:i:s'),
+            'created_at' => $this->created_at?->format('Y-m-d H:i:s'),
+            'updated_at' => $this->updated_at?->format('Y-m-d H:i:s'),
+            'branch_id' => $this->branch_id,
+            'created_by' => $this->whenLoaded('user', fn () => [
+                'id' => $this->user_id,
+                'name' => $this->user?->name,
+            ]),
+            'customer' => $this->whenLoaded('customer', fn () => [
+                'id' => $this->customer->id,
+                'name' => $this->customer->display_name,
+                'phone' => null,
+                'email' => null,
+            ]),
+            'delivery_address' => $this->getDeliveryAddress(),
             'items' => OperationItemResource::collection($this->whenLoaded('items')),
             'payments' => OperationPaymentResource::collection($this->whenLoaded('payments')),
             'events' => CommercialOperationEventResource::collection($this->whenLoaded('events')),
-            'created_at' => $this->created_at?->format('Y-m-d H:i:s'),
-            'updated_at' => $this->updated_at?->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    private function getDeliveryAddress(): ?array
+    {
+        $address = $this->delivery_address;
+
+        if (! $address) {
+            return null;
+        }
+
+        $street = $address->street ?? '';
+        $number = $address->number ?? '';
+        $fullAddress = trim($street.' '.$number);
+
+        return [
+            'id' => $address->id,
+            'street' => $address->street,
+            'number' => $address->number,
+            'locality' => $address->locality?->name,
+            'province' => $address->locality?->province?->name,
+            'notes' => $address->observations,
+            'full_address' => $fullAddress ?: null,
         ];
     }
 }

--- a/app/Models/CommercialOperation.php
+++ b/app/Models/CommercialOperation.php
@@ -115,6 +115,19 @@ class CommercialOperation extends Model
         return $query;
     }
 
+    public function getDeliveryAddressAttribute(): ?CustomerAddress
+    {
+        if ($this->relationLoaded('customer')) {
+            $customer = $this->customer;
+
+            if ($customer && $customer->relationLoaded('addresses')) {
+                return $customer->addresses->firstWhere('is_main', true);
+            }
+        }
+
+        return null;
+    }
+
     public static function generateNumber(string $type, string $storeId): string
     {
         if (! in_array($type, ['sale', 'order'])) {

--- a/config/permissions_catalog.php
+++ b/config/permissions_catalog.php
@@ -2,6 +2,7 @@
 
 return [
     'Pedidos' => [
+        ['name' => 'orders.view', 'label' => 'Ver'],
         ['name' => 'orders.edit', 'label' => 'Editar'],
     ],
     'Inventario' => [

--- a/database/factories/CommercialOperationEventFactory.php
+++ b/database/factories/CommercialOperationEventFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CommercialOperation;
+use App\Models\CommercialOperationEvent;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CommercialOperationEventFactory extends Factory
+{
+    protected $model = CommercialOperationEvent::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id' => Store::factory(),
+            'operation_id' => CommercialOperation::factory(),
+            'event_type' => $this->faker->randomElement(['created', 'reschedule', 'cancel', 'confirm', 'close']),
+            'previous_date' => now()->format('Y-m-d'),
+            'new_date' => now()->addDays(7)->format('Y-m-d'),
+            'reason' => $this->faker->randomElement(['created', 'customer_requested_reschedule', 'customer_cancelled', 'completed', 'other']),
+            'observation' => null,
+            'user_id' => User::factory(),
+            'previous_status' => null,
+            'new_status' => null,
+            'reason_code' => null,
+            'reason_note' => null,
+        ];
+    }
+}

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -64,6 +64,7 @@ class PermissionSeeder extends Seeder
       'store_payment_methods.configure',
       
       // Module: Orders
+      'orders.view',
       'orders.edit',
     ];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Api\V1\Store\CategoryController;
 use App\Http\Controllers\Api\V1\Store\CommercialGroupController;
 use App\Http\Controllers\Api\V1\Store\CommercialOperationController;
 use App\Http\Controllers\Api\V1\Store\CustomerAddressController;
+use App\Http\Controllers\Api\V1\Store\OrderController;
 use App\Http\Controllers\Api\V1\Store\CustomerContactController;
 use App\Http\Controllers\Api\V1\Store\CustomerController;
 use App\Http\Controllers\Api\V1\Store\GenerateSkuController;
@@ -142,6 +143,13 @@ Route::prefix('v1')->group(function () {
             });
 
             Route::middleware('feature:pos')->group(function () {
+                Route::get('orders', [OrderController::class, 'index'])
+                    ->middleware('permission:orders.view')
+                    ->name('store.orders.index');
+                Route::get('orders/{id}', [OrderController::class, 'show'])
+                    ->middleware('permission:orders.view')
+                    ->name('store.orders.show');
+
                 Route::get('operations', [CommercialOperationController::class, 'index'])->name('store.operations.index');
                 Route::get('operations/{operation}', [CommercialOperationController::class, 'show'])->name('store.operations.show');
                 Route::post('operations', [CommercialOperationController::class, 'store'])->name('store.operations.store');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -11562,6 +11562,229 @@
                 ]
             }
         },
+        "/store/orders": {
+            "get": {
+                "tags": [
+                    "Store - Pedidos"
+                ],
+                "summary": "Listar pedidos de la tienda",
+                "description": "Listado paginado de pedidos de la tienda.",
+                "operationId": "7aa6e43494d62e32f62c517e1169bd82",
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Filtrar por fecha de entrega (YYYY-MM-DD). Ignora date_from y date_to.",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "date_from",
+                        "in": "query",
+                        "description": "Filtrar desde fecha (YYYY-MM-DD)",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "date_to",
+                        "in": "query",
+                        "description": "Filtrar hasta fecha (YYYY-MM-DD)",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filtrar por estado. Default: activos (open, confirmed)",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "open",
+                                "confirmed",
+                                "cancelled",
+                                "closed"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "operation_number",
+                        "in": "query",
+                        "description": "Búsqueda por número de pedido (parcial)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "customer_name",
+                        "in": "query",
+                        "description": "Búsqueda por nombre de cliente",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "locality",
+                        "in": "query",
+                        "description": "Búsqueda por localidad del domicilio de entrega",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "Items por página",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Número de página",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Pedidos obtenidos exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Pedidos obtenidos exitosamente."
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/CommercialOperationListResource"
+                                                    }
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 25
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "example": 20
+                                                },
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "example": 2
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "No autenticado"
+                    },
+                    "403": {
+                        "description": "Sin permisos"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/store/orders/{id}": {
+            "get": {
+                "tags": [
+                    "Store - Pedidos"
+                ],
+                "summary": "Ver detalle de un pedido",
+                "description": "Detalle completo de un pedido.",
+                "operationId": "35a0e947a449f5b95dd6236c319108d2",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Pedido obtenido exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Pedido obtenido exitosamente."
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/CommercialOperationResource"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "No autenticado"
+                    },
+                    "403": {
+                        "description": "Sin permisos"
+                    },
+                    "404": {
+                        "description": "Pedido no encontrado"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/store/payment-methods": {
             "get": {
                 "tags": [
@@ -13187,6 +13410,177 @@
     },
     "components": {
         "schemas": {
+            "CommercialOperationEventResource": {
+                "title": "CommercialOperationEventResource",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "event_type": {
+                        "type": "string"
+                    },
+                    "previous_status": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "new_status": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "reason_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "reason_note": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "observation": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "old_values": {
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "date": {
+                                "type": "string",
+                                "format": "date",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "new_values": {
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "date": {
+                                "type": "string",
+                                "format": "date",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "user": {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "CommercialOperationListResource": {
+                "title": "CommercialOperationListResource",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "operation_number": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "requested_delivery_date": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "delivery_time_from": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "delivery_time_to": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "total": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "paid_amount": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "pending_amount": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "items_count": {
+                        "type": "integer"
+                    },
+                    "customer": {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "phone": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "delivery_address": {
+                        "properties": {
+                            "locality": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "street": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "full_address": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "branch_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
             "CommercialOperationResource": {
                 "title": "CommercialOperationResource",
                 "properties": {
@@ -13203,25 +13597,19 @@
                     "status": {
                         "type": "string"
                     },
-                    "customer": {
-                        "type": "object",
+                    "requested_delivery_date": {
+                        "type": "string",
+                        "format": "date",
                         "nullable": true
                     },
-                    "user": {
-                        "properties": {
-                            "id": {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            "name": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    },
-                    "branch_id": {
+                    "delivery_time_from": {
                         "type": "string",
-                        "format": "uuid",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "delivery_time_to": {
+                        "type": "string",
+                        "example": null,
                         "nullable": true
                     },
                     "subtotal": {
@@ -13240,14 +13628,96 @@
                         "type": "number",
                         "format": "float"
                     },
-                    "delivery_date": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
+                    "paid_amount": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "pending_amount": {
+                        "type": "number",
+                        "format": "float"
                     },
                     "completed_at": {
                         "type": "string",
                         "format": "date-time",
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "branch_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true
+                    },
+                    "created_by": {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "customer": {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "phone": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "email": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "delivery_address": {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "street": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "number": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "locality": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "province": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "notes": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "full_address": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object",
                         "nullable": true
                     },
                     "items": {
@@ -13262,13 +13732,11 @@
                             "$ref": "#/components/schemas/OperationPaymentResource"
                         }
                     },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time"
+                    "events": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CommercialOperationEventResource"
+                        }
                     }
                 },
                 "type": "object"
@@ -14688,6 +15156,10 @@
         {
             "name": "Store - Inventario",
             "description": "Store - Inventario"
+        },
+        {
+            "name": "Store - Pedidos",
+            "description": "Store - Pedidos"
         },
         {
             "name": "Store - Payment Methods",

--- a/tests/Feature/Api/V1/Store/OrdersDetailTest.php
+++ b/tests/Feature/Api/V1/Store/OrdersDetailTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\CustomerAddress;
+use App\Models\Feature;
+use App\Models\Locality;
+use App\Models\OperationItem;
+use App\Models\OperationPayment;
+use App\Models\PaymentMethod;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\Province;
+use App\Models\Store;
+use App\Models\StorePaymentMethod;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_USER', 'guard_name' => 'web']);
+    Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'BACKOFFICE_USER', 'guard_name' => 'web']);
+
+    Permission::firstOrCreate(['name' => 'orders.view', 'guard_name' => 'web']);
+    Permission::firstOrCreate(['name' => 'orders.edit', 'guard_name' => 'web']);
+
+    $this->store = Store::factory()->create();
+    $this->plan = Plan::factory()->create();
+    $this->store->plan_id = $this->plan->id;
+    $this->store->save();
+
+    $posFeature = Feature::firstOrCreate(['code' => 'pos', 'name' => 'Punto de Venta']);
+    $this->plan->features()->syncWithoutDetaching([$posFeature->id => ['limit_value' => null]]);
+
+    $this->customer = Customer::factory()->create(['store_id' => $this->store->id]);
+    $this->province = Province::factory()->create();
+    $this->locality = Locality::factory()->create(['province_id' => $this->province->id]);
+    $this->address = CustomerAddress::factory()->create([
+        'customer_id' => $this->customer->id,
+        'locality_id' => $this->locality->id,
+        'is_main' => true,
+        'street' => 'Av. Corrientes',
+        'number' => '1234',
+        'observations' => 'Timbre 4B',
+    ]);
+
+    $this->product = Product::factory()->create([
+        'store_id' => $this->store->id,
+        'name' => 'Producto Test',
+        'price' => 100.00,
+    ]);
+
+    $this->user = User::factory()->create(['store_id' => $this->store->id]);
+    $this->user->assignRole('STORE_ADMIN');
+    $this->user->givePermissionTo('orders.view');
+    $this->token = $this->user->createToken('test-token')->plainTextToken;
+});
+
+function makeDetailUser(Store $store, string $role = 'STORE_ADMIN', array $permissions = []): User
+{
+    $user = User::factory()->create(['store_id' => $store->id]);
+    $user->assignRole($role);
+
+    foreach ($permissions as $perm) {
+        Permission::firstOrCreate(['name' => $perm, 'guard_name' => 'web']);
+        $user->givePermissionTo($perm);
+    }
+
+    return $user;
+}
+
+function createDetailOrder(Store $store, array $attributes = []): \App\Models\CommercialOperation
+{
+    $user = User::factory()->create(['store_id' => $store->id]);
+
+    return \App\Models\CommercialOperation::factory()->create(array_merge([
+        'store_id' => $store->id,
+        'user_id' => $user->id,
+        'type' => 'order',
+        'status' => 'open',
+    ], $attributes));
+}
+
+function getOrderDetail(string $id, ?string $token = null): \Illuminate\Testing\TestResponse
+{
+    $token = $token ?? test()->token;
+
+    return test()->withHeader('Authorization', 'Bearer '.$token)
+        ->getJson('/api/v1/store/orders/'.$id);
+}
+
+function makePaymentMethodForStoreDetail(Store $store): StorePaymentMethod
+{
+    $paymentMethod = PaymentMethod::factory()->create();
+
+    return StorePaymentMethod::factory()->create([
+        'store_id' => $store->id,
+        'payment_method_id' => $paymentMethod->id,
+    ]);
+}
+
+describe('GET /api/v1/store/orders/{id} — Orders Detail', function () {
+    test('unauthenticated request returns 401', function () {
+        $order = createDetailOrder($this->store);
+        $response = $this->getJson('/api/v1/store/orders/'.$order->id);
+        $response->assertStatus(401);
+    });
+
+    test('user without orders.view permission returns 403', function () {
+        $order = createDetailOrder($this->store);
+        $userWithoutPerm = makeDetailUser($this->store, 'STORE_USER');
+        $token = $userWithoutPerm->createToken('test-token')->plainTextToken;
+
+        $response = getOrderDetail($order->id, $token);
+
+        $response->assertStatus(403);
+    });
+
+    test('returns full order detail', function () {
+        $order = createDetailOrder($this->store, [
+            'customer_id' => $this->customer->id,
+            'total' => 500.00,
+            'subtotal' => 400.00,
+            'tax' => 80.00,
+            'discount' => 20.00,
+            'requested_delivery_date' => '2026-08-15',
+            'completed_at' => now()->subDay(),
+        ]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.id', $order->id)
+            ->assertJsonPath('data.operation_number', $order->operation_number)
+            ->assertJsonPath('data.type', 'order')
+            ->assertJsonPath('data.status', 'open')
+            ->assertJsonPath('data.requested_delivery_date', '2026-08-15');
+        $data = $response->json('data');
+        expect((float) $data['subtotal'])->toBe(400.00);
+        expect((float) $data['tax'])->toBe(80.00);
+        expect((float) $data['discount'])->toBe(20.00);
+        expect((float) $data['total'])->toBe(500.00);
+    });
+
+    test('returns 404 for non-existent order', function () {
+        $fakeId = (string) \Illuminate\Support\Str::uuid();
+
+        $response = getOrderDetail($fakeId);
+
+        $response->assertStatus(404);
+    });
+
+    test('returns 404 for type sale operation', function () {
+        $sale = \App\Models\CommercialOperation::factory()->create([
+            'store_id' => $this->store->id,
+            'user_id' => $this->user->id,
+            'type' => 'sale',
+            'status' => 'confirmed',
+        ]);
+
+        $response = getOrderDetail($sale->id);
+
+        $response->assertStatus(404);
+    });
+
+    test('returns 404 for order from different store', function () {
+        $otherStore = Store::factory()->create();
+        $otherPlan = Plan::factory()->create();
+        $otherStore->plan_id = $otherPlan->id;
+        $otherStore->save();
+        $posFeature = Feature::firstOrCreate(['code' => 'pos', 'name' => 'Punto de Venta']);
+        $otherPlan->features()->syncWithoutDetaching([$posFeature->id => ['limit_value' => null]]);
+
+        $otherOrder = createDetailOrder($otherStore);
+
+        $response = getOrderDetail($otherOrder->id);
+
+        $response->assertStatus(404);
+    });
+
+    test('includes items with product info', function () {
+        $order = createDetailOrder($this->store);
+        OperationItem::factory()->create([
+            'operation_id' => $order->id,
+            'product_id' => $this->product->id,
+            'product_name' => $this->product->name,
+            'quantity' => 3,
+            'price' => 100.00,
+            'subtotal' => 300.00,
+        ]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        $items = $response->json('data.items');
+        expect($items)->toHaveCount(1);
+        expect($items[0]['product_id'])->toBe($this->product->id);
+        expect($items[0]['product_name'])->toBe($this->product->name);
+        expect($items[0]['quantity'])->toBe(3);
+    });
+
+    test('includes payments with payment method', function () {
+        $order = createDetailOrder($this->store, ['total' => 300.00]);
+        $spm = makePaymentMethodForStoreDetail($this->store);
+        OperationPayment::factory()->create([
+            'operation_id' => $order->id,
+            'store_payment_method_id' => $spm->id,
+            'amount' => 300.00,
+        ]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        $payments = $response->json('data.payments');
+        expect($payments)->toHaveCount(1);
+        expect((float) $payments[0]['amount'])->toBe(300.00);
+        expect($payments[0]['store_payment_method']['name'])->not->toBeNull();
+    });
+
+    test('paid_amount and pending_amount are correct', function () {
+        $order = createDetailOrder($this->store, ['total' => 1000.00]);
+        $spm = makePaymentMethodForStoreDetail($this->store);
+        OperationPayment::factory()->create([
+            'operation_id' => $order->id,
+            'store_payment_method_id' => $spm->id,
+            'amount' => 600.00,
+        ]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        expect((float) $response->json('data.paid_amount'))->toBe(600.00);
+        expect((float) $response->json('data.pending_amount'))->toBe(400.00);
+    });
+
+    test('includes events with user', function () {
+        $order = createDetailOrder($this->store);
+        $eventUser = User::factory()->create(['store_id' => $this->store->id]);
+
+        \App\Models\CommercialOperationEvent::factory()->create([
+            'store_id' => $this->store->id,
+            'operation_id' => $order->id,
+            'event_type' => 'reschedule',
+            'previous_date' => '2026-07-20',
+            'new_date' => '2026-07-25',
+            'previous_status' => 'open',
+            'new_status' => 'open',
+            'reason_code' => 'customer_requested_reschedule',
+            'reason_note' => 'Customer asked to change',
+            'user_id' => $eventUser->id,
+        ]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        $events = $response->json('data.events');
+        expect($events)->toHaveCount(1);
+        expect($events[0]['event_type'])->toBe('reschedule');
+        expect($events[0]['reason_code'])->toBe('customer_requested_reschedule');
+        expect($events[0]['old_values']['status'])->toBe('open');
+        expect($events[0]['old_values']['date'])->toBe('2026-07-20');
+        expect($events[0]['new_values']['status'])->toBe('open');
+        expect($events[0]['new_values']['date'])->toBe('2026-07-25');
+        expect($events[0]['user'])->not->toBeNull();
+        expect($events[0]['user']['id'])->toBe($eventUser->id);
+    });
+
+    test('includes delivery_address from customer main address', function () {
+        $order = createDetailOrder($this->store, ['customer_id' => $this->customer->id]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        $address = $response->json('data.delivery_address');
+        expect($address)->not->toBeNull();
+        expect($address['id'])->toBe($this->address->id);
+        expect($address['street'])->toBe('Av. Corrientes');
+        expect($address['number'])->toBe('1234');
+        expect($address['locality'])->toBe($this->locality->name);
+        expect($address['province'])->toBe($this->province->name);
+        expect($address['notes'])->toBe('Timbre 4B');
+        expect($address['full_address'])->toBe('Av. Corrientes 1234');
+    });
+
+    test('includes created_by from user relationship', function () {
+        $creator = User::factory()->create(['store_id' => $this->store->id, 'name' => 'Creator User']);
+        $order = createDetailOrder($this->store, ['user_id' => $creator->id]);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        expect($response->json('data.created_by'))->not->toBeNull();
+        expect($response->json('data.created_by.id'))->toBe($creator->id);
+        expect($response->json('data.created_by.name'))->toBe('Creator User');
+    });
+
+    test('delivery_time_from and delivery_time_to are null', function () {
+        $order = createDetailOrder($this->store);
+
+        $response = getOrderDetail($order->id);
+
+        $response->assertStatus(200);
+        expect($response->json('data.delivery_time_from'))->toBeNull();
+        expect($response->json('data.delivery_time_to'))->toBeNull();
+    });
+});

--- a/tests/Feature/Api/V1/Store/OrdersListTest.php
+++ b/tests/Feature/Api/V1/Store/OrdersListTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\CustomerAddress;
+use App\Models\Feature;
+use App\Models\Locality;
+use App\Models\OperationPayment;
+use App\Models\PaymentMethod;
+use App\Models\Plan;
+use App\Models\Province;
+use App\Models\Store;
+use App\Models\StorePaymentMethod;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_USER', 'guard_name' => 'web']);
+    Role::create(['name' => 'SUPER_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'BACKOFFICE_USER', 'guard_name' => 'web']);
+
+    Permission::firstOrCreate(['name' => 'orders.view', 'guard_name' => 'web']);
+
+    $this->store = Store::factory()->create();
+    $this->plan = Plan::factory()->create();
+    $this->store->plan_id = $this->plan->id;
+    $this->store->save();
+
+    $posFeature = Feature::firstOrCreate(['code' => 'pos', 'name' => 'Punto de Venta']);
+    $this->plan->features()->syncWithoutDetaching([$posFeature->id => ['limit_value' => null]]);
+
+    $this->customer = Customer::factory()->create(['store_id' => $this->store->id]);
+    $this->province = Province::factory()->create();
+    $this->locality = Locality::factory()->create(['province_id' => $this->province->id]);
+    $this->address = CustomerAddress::factory()->create([
+        'customer_id' => $this->customer->id,
+        'locality_id' => $this->locality->id,
+        'is_main' => true,
+        'street' => 'Av. Corrientes',
+        'number' => '1234',
+    ]);
+
+    $this->user = User::factory()->create(['store_id' => $this->store->id]);
+    $this->user->assignRole('STORE_ADMIN');
+    $this->user->givePermissionTo('orders.view');
+    $this->token = $this->user->createToken('test-token')->plainTextToken;
+});
+
+function makeListUser(Store $store, string $role = 'STORE_ADMIN', array $permissions = []): User
+{
+    $user = User::factory()->create(['store_id' => $store->id]);
+    $user->assignRole($role);
+
+    foreach ($permissions as $perm) {
+        Permission::firstOrCreate(['name' => $perm, 'guard_name' => 'web']);
+        $user->givePermissionTo($perm);
+    }
+
+    return $user;
+}
+
+function createOrderForStore(Store $store, array $attributes = []): \App\Models\CommercialOperation
+{
+    $user = User::factory()->create(['store_id' => $store->id]);
+
+    return \App\Models\CommercialOperation::factory()->create(array_merge([
+        'store_id' => $store->id,
+        'user_id' => $user->id,
+        'type' => 'order',
+        'status' => 'open',
+    ], $attributes));
+}
+
+function listOrders(array $filters = [], ?string $token = null): \Illuminate\Testing\TestResponse
+{
+    $query = http_build_query($filters);
+    $token = $token ?? test()->token;
+
+    return test()->withHeader('Authorization', 'Bearer '.$token)
+        ->getJson('/api/v1/store/orders?'.$query);
+}
+
+describe('GET /api/v1/store/orders — Orders List', function () {
+    test('unauthenticated request returns 401', function () {
+        $response = $this->getJson('/api/v1/store/orders');
+        $response->assertStatus(401);
+    });
+
+    test('user without orders.view permission returns 403', function () {
+        $userWithoutPerm = makeListUser($this->store, 'STORE_USER');
+        $token = $userWithoutPerm->createToken('test-token')->plainTextToken;
+
+        $response = listOrders([], $token);
+
+        $response->assertStatus(403);
+    });
+
+    test('returns paginated orders for current store only', function () {
+        $order1 = createOrderForStore($this->store);
+        $order2 = createOrderForStore($this->store);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($order1->id)
+            ->toContain($order2->id);
+    });
+
+    test('does not return orders from other stores', function () {
+        $otherStore = Store::factory()->create();
+        $otherPlan = Plan::factory()->create();
+        $otherStore->plan_id = $otherPlan->id;
+        $otherStore->save();
+        $posFeature = Feature::firstOrCreate(['code' => 'pos', 'name' => 'Punto de Venta']);
+        $otherPlan->features()->syncWithoutDetaching([$posFeature->id => ['limit_value' => null]]);
+
+        $myOrder = createOrderForStore($this->store);
+        $otherOrder = createOrderForStore($otherStore);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($myOrder->id)
+            ->not()->toContain($otherOrder->id);
+    });
+
+    test('only returns type order operations', function () {
+        $order = createOrderForStore($this->store);
+        $sale = \App\Models\CommercialOperation::factory()->create([
+            'store_id' => $this->store->id,
+            'user_id' => $this->user->id,
+            'type' => 'sale',
+            'status' => 'confirmed',
+        ]);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($order->id)
+            ->not()->toContain($sale->id);
+    });
+
+    test('filters by status', function () {
+        $openOrder = createOrderForStore($this->store, ['status' => 'open']);
+        $cancelledOrder = createOrderForStore($this->store, ['status' => 'cancelled']);
+
+        $response = listOrders(['status' => 'cancelled']);
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($cancelledOrder->id)
+            ->not()->toContain($openOrder->id);
+    });
+
+    test('default filter shows only open and confirmed orders', function () {
+        $openOrder = createOrderForStore($this->store, ['status' => 'open']);
+        $confirmedOrder = createOrderForStore($this->store, ['status' => 'confirmed']);
+        $cancelledOrder = createOrderForStore($this->store, ['status' => 'cancelled']);
+        $closedOrder = createOrderForStore($this->store, ['status' => 'closed']);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($openOrder->id)
+            ->toContain($confirmedOrder->id)
+            ->not()->toContain($cancelledOrder->id)
+            ->not()->toContain($closedOrder->id);
+    });
+
+    test('filters by requested_delivery_date', function () {
+        $matchingDate = '2026-12-25';
+        $order1 = createOrderForStore($this->store, ['requested_delivery_date' => $matchingDate]);
+        $order2 = createOrderForStore($this->store, ['requested_delivery_date' => '2026-12-26']);
+
+        $response = listOrders(['date' => $matchingDate]);
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($order1->id)
+            ->not()->toContain($order2->id);
+    });
+
+    test('filters by date range', function () {
+        $orderInRange = createOrderForStore($this->store, ['requested_delivery_date' => '2026-07-15']);
+        $orderBefore = createOrderForStore($this->store, ['requested_delivery_date' => '2026-06-01']);
+        $orderAfter = createOrderForStore($this->store, ['requested_delivery_date' => '2026-08-01']);
+
+        $response = listOrders([
+            'date_from' => '2026-07-01',
+            'date_to' => '2026-07-31',
+        ]);
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($orderInRange->id)
+            ->not()->toContain($orderBefore->id)
+            ->not()->toContain($orderAfter->id);
+    });
+
+    test('filters by operation_number partial match', function () {
+        $order1 = createOrderForStore($this->store, ['operation_number' => 'P-000042']);
+        $order2 = createOrderForStore($this->store, ['operation_number' => 'P-000099']);
+
+        $response = listOrders(['operation_number' => '42']);
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($order1->id)
+            ->not()->toContain($order2->id);
+    });
+
+    test('filters by customer_name partial match', function () {
+        $customerA = Customer::factory()->create(['store_id' => $this->store->id, 'display_name' => 'Juan Perez']);
+        $customerB = Customer::factory()->create(['store_id' => $this->store->id, 'display_name' => 'Maria Garcia']);
+
+        $order1 = createOrderForStore($this->store, ['customer_id' => $customerA->id]);
+        $order2 = createOrderForStore($this->store, ['customer_id' => $customerB->id]);
+
+        $response = listOrders(['customer_name' => 'Perez']);
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($order1->id)
+            ->not()->toContain($order2->id);
+    });
+
+    test('filters by locality', function () {
+        $localityA = Locality::factory()->create(['province_id' => $this->province->id, 'name' => 'Palermo']);
+        $localityB = Locality::factory()->create(['province_id' => $this->province->id, 'name' => 'Belgrano']);
+
+        $customerA = Customer::factory()->create(['store_id' => $this->store->id]);
+        $customerB = Customer::factory()->create(['store_id' => $this->store->id]);
+
+        CustomerAddress::factory()->create([
+            'customer_id' => $customerA->id,
+            'locality_id' => $localityA->id,
+            'is_main' => true,
+        ]);
+        CustomerAddress::factory()->create([
+            'customer_id' => $customerB->id,
+            'locality_id' => $localityB->id,
+            'is_main' => true,
+        ]);
+
+        $order1 = createOrderForStore($this->store, ['customer_id' => $customerA->id]);
+        $order2 = createOrderForStore($this->store, ['customer_id' => $customerB->id]);
+
+        $response = listOrders(['locality' => 'Palermo']);
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids)->toContain($order1->id)
+            ->not()->toContain($order2->id);
+    });
+
+    test('correct sort order — delivery_date ASC, operation_number ASC', function () {
+        $order1 = createOrderForStore($this->store, [
+            'requested_delivery_date' => '2026-07-20',
+            'operation_number' => 'P-000003',
+        ]);
+        $order2 = createOrderForStore($this->store, [
+            'requested_delivery_date' => '2026-07-20',
+            'operation_number' => 'P-000001',
+        ]);
+        $order3 = createOrderForStore($this->store, [
+            'requested_delivery_date' => '2026-07-18',
+            'operation_number' => 'P-000005',
+        ]);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.items'))->pluck('id')->toArray();
+        expect($ids[0])->toBe($order3->id);
+        expect($ids[1])->toBe($order2->id);
+        expect($ids[2])->toBe($order1->id);
+    });
+
+    test('includes paid_amount and pending_amount calculations', function () {
+        $order = createOrderForStore($this->store, [
+            'total' => 1000.00,
+            'status' => 'open',
+        ]);
+
+        $paymentMethod = PaymentMethod::factory()->create();
+        $storePaymentMethod = StorePaymentMethod::factory()->create([
+            'store_id' => $this->store->id,
+            'payment_method_id' => $paymentMethod->id,
+        ]);
+        OperationPayment::factory()->create([
+            'operation_id' => $order->id,
+            'store_payment_method_id' => $storePaymentMethod->id,
+            'amount' => 400.00,
+        ]);
+        OperationPayment::factory()->create([
+            'operation_id' => $order->id,
+            'store_payment_method_id' => $storePaymentMethod->id,
+            'amount' => 200.00,
+        ]);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $data = collect($response->json('data.items'))->firstWhere('id', $order->id);
+        expect($data)->not->toBeNull();
+        expect((float) $data['paid_amount'])->toBe(600.00);
+        expect((float) $data['pending_amount'])->toBe(400.00);
+    });
+
+    test('includes delivery_address from customer main address', function () {
+        $order = createOrderForStore($this->store, [
+            'customer_id' => $this->customer->id,
+        ]);
+
+        $response = listOrders();
+
+        $response->assertStatus(200);
+        $data = collect($response->json('data.items'))->firstWhere('id', $order->id);
+        expect($data['delivery_address'])->not->toBeNull();
+        expect($data['delivery_address']['street'])->toBe('Av. Corrientes');
+        expect($data['delivery_address']['full_address'])->toBe('Av. Corrientes 1234');
+        expect($data['delivery_address']['locality'])->toBe($this->locality->name);
+    });
+});

--- a/tests/Unit/Resources/CommercialOperationResourceTest.php
+++ b/tests/Unit/Resources/CommercialOperationResourceTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use App\Http\Resources\CommercialOperationResource;
-use App\Models\Category;
 use App\Models\CommercialOperation;
 use App\Models\Customer;
 use App\Models\Store;
@@ -15,7 +14,7 @@ uses(Tests\TestCase::class);
 uses(RefreshDatabase::class);
 
 describe('CommercialOperationResource', function () {
-    test('returns delivery_date from requested_delivery_date attribute', function () {
+    test('returns requested_delivery_date from requested_delivery_date attribute', function () {
         $store = Store::factory()->create();
         $customer = Customer::factory()->create(['store_id' => $store->id]);
         $user = User::factory()->create(['store_id' => $store->id]);
@@ -30,13 +29,13 @@ describe('CommercialOperationResource', function () {
         ]);
 
         $resource = CommercialOperationResource::make($operation);
-        $data = $resource->toArray(new Request());
+        $data = $resource->toArray(new Request);
 
-        expect($data)->toHaveKey('delivery_date')
-            ->and($data['delivery_date'])->toBe('2026-07-25');
+        expect($data)->toHaveKey('requested_delivery_date')
+            ->and($data['requested_delivery_date'])->toBe('2026-07-25');
     });
 
-    test('delivery_date is null when requested_delivery_date is null', function () {
+    test('requested_delivery_date is null when requested_delivery_date is null', function () {
         $store = Store::factory()->create();
         $user = User::factory()->create(['store_id' => $store->id]);
 
@@ -49,8 +48,8 @@ describe('CommercialOperationResource', function () {
         ]);
 
         $resource = CommercialOperationResource::make($operation);
-        $data = $resource->toArray(new Request());
+        $data = $resource->toArray(new Request);
 
-        expect($data['delivery_date'])->toBeNull();
+        expect($data['requested_delivery_date'])->toBeNull();
     });
 });


### PR DESCRIPTION
- Added 'orders.view' permission in PermissionSeeder.
- Implemented API routes for listing and viewing order details.
- Updated API documentation to include new endpoints for orders.
- Created tests for orders listing and detail retrieval, ensuring proper permission checks and data integrity.
- Enhanced CommercialOperationResource to return requested_delivery_date correctly.