### PR TITLE
feat: Add RouteStopFactory for generating route stop data

### DIFF
--- a/app/Http/Controllers/Api/V1/Driver/DriverExecutionController.php
+++ b/app/Http/Controllers/Api/V1/Driver/DriverExecutionController.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Driver\CompleteStopRequest;
+use App\Http\Resources\DeliveryRouteResource;
+use App\Http\Resources\RouteStopResource;
+use App\Models\RouteStop;
+use App\Services\DriverExecutionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DriverExecutionController extends Controller
+{
+    public function __construct(
+        private readonly DriverExecutionService $executionService,
+    ) {}
+
+    /**
+     * Get the active (dispatched) route for the authenticated driver.
+     *
+     * @OA\Get(
+     *   path="/driver/active-route",
+     *   summary="Obtener ruta activa del conductor",
+     *   tags={"Driver"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Ruta activa obtenida exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="null", example=null),
+     *       @OA\Property(property="data", ref="#/components/schemas/DriverActiveRoute"),
+     *       @OA\Property(property="errors", type="null", example=null),
+     *       @OA\Property(property="meta", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(
+     *     response=404,
+     *     description="No se encontró una ruta despachada para este conductor.",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="error"),
+     *       @OA\Property(property="message", type="string", example="No se encontró una ruta activa para este conductor."),
+     *       @OA\Property(property="data", type="null", example=null),
+     *       @OA\Property(property="errors", type="object", example={"error": {"No se encontró una ruta despachada para este conductor."}})
+     *     )
+     *   )
+     * )
+     */
+    public function activeRoute(Request $request): JsonResponse
+    {
+        $driver = $request->user();
+        $route = $this->executionService->getActiveRoute($driver);
+
+        if (! $route) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'No se encontró una ruta activa para este conductor.',
+                'data' => null,
+                'errors' => ['error' => ['No se encontró una ruta despachada para este conductor.']],
+            ], 404);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => null,
+            'data' => DeliveryRouteResource::make($route),
+            'errors' => null,
+            'meta' => null,
+        ]);
+    }
+
+    /**
+     * Mark arrival at a stop, optionally recording GPS coordinates.
+     *
+     * @OA\Post(
+     *   path="/driver/stops/{stop}/arrive",
+     *   summary="Registrar llegada a una parada",
+     *   tags={"Driver"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
+     *
+     *   @OA\RequestBody(
+     *     required=false,
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="gps_lat", type="number", example=-34.6037, nullable=true),
+     *       @OA\Property(property="gps_lon", type="number", example=-58.3816, nullable=true)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Llegada registrada exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="null", example=null),
+     *       @OA\Property(property="data", ref="#/components/schemas/RouteStop"),
+     *       @OA\Property(property="errors", type="null", example=null),
+     *       @OA\Property(property="meta", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=403, description="Conductor no asignado a esta parada"),
+     *   @OA\Response(response=404, description="Parada no encontrada")
+     * )
+     */
+    public function arrive(Request $request, string $stopId): JsonResponse
+    {
+        $driver = $request->user();
+        $stop = RouteStop::findOrFail($stopId);
+
+        $stop = $this->executionService->arriveStop($stop, $request->only(['gps_lat', 'gps_lon']), $driver);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => null,
+            'data' => RouteStopResource::make($stop),
+            'errors' => null,
+            'meta' => null,
+        ]);
+    }
+
+    /**
+     * Complete a stop delivery with item-level quantities.
+     *
+     * @OA\Post(
+     *   path="/driver/stops/{stop}/complete",
+     *   summary="Completar entrega de una parada",
+     *   tags={"Driver"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
+     *
+     *   @OA\RequestBody(
+     *     required=true,
+     *
+     *     @OA\JsonContent(
+     *       required={"status", "items"},
+     *
+     *       @OA\Property(property="status", type="string", enum={"completed", "failed"}, example="completed"),
+     *       @OA\Property(property="gps_lat", type="number", example=-34.6037, nullable=true),
+     *       @OA\Property(property="gps_lon", type="number", example=-58.3816, nullable=true),
+     *       @OA\Property(property="rejection_reason_id", type="string", format="uuid", nullable=true, description="Requerido si status=failed"),
+     *       @OA\Property(
+     *         property="items",
+     *         type="array",
+     *
+     *         @OA\Items(
+     *           required={"route_stop_item_id", "quantity_delivered"},
+     *
+     *           @OA\Property(property="route_stop_item_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
+     *           @OA\Property(property="quantity_delivered", type="integer", example=5),
+     *           @OA\Property(property="rejection_reason_id", type="string", format="uuid", nullable=true)
+     *         )
+     *       )
+     *     )
+     *   ),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Entrega completada exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="null", example=null),
+     *       @OA\Property(property="data", ref="#/components/schemas/RouteStop"),
+     *       @OA\Property(property="errors", type="null", example=null),
+     *       @OA\Property(property="meta", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=403, description="Conductor no asignado a esta parada"),
+     *   @OA\Response(response=404, description="Parada no encontrada"),
+     *   @OA\Response(response=422, description="Error de validación")
+     * )
+     */
+    public function complete(CompleteStopRequest $request, string $stopId): JsonResponse
+    {
+        $driver = $request->user();
+        $stop = RouteStop::findOrFail($stopId);
+
+        $stop = $this->executionService->completeStop($stop, $request->validated(), $driver);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => null,
+            'data' => RouteStopResource::make($stop),
+            'errors' => null,
+            'meta' => null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/V1/Driver/CompleteStopRequest.php
+++ b/app/Http/Requests/Api/V1/Driver/CompleteStopRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Driver;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class CompleteStopRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', 'string', 'in:completed,failed'],
+            'gps_lat' => ['nullable', 'numeric'],
+            'gps_lon' => ['nullable', 'numeric'],
+            'rejection_reason_id' => [
+                'required_if:status,failed',
+                'uuid',
+                'exists:delivery_rejection_reasons,id',
+            ],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.route_stop_item_id' => [
+                'required',
+                'uuid',
+                'exists:route_stop_items,id',
+            ],
+            'items.*.quantity_delivered' => [
+                'required',
+                'integer',
+                'min:0',
+            ],
+            'items.*.rejection_reason_id' => [
+                'nullable',
+                'uuid',
+                'exists:delivery_rejection_reasons,id',
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'status.required' => 'El estado de la entrega es obligatorio.',
+            'status.in' => 'El estado debe ser completed o failed.',
+            'rejection_reason_id.required_if' => 'El motivo de rechazo es obligatorio cuando la entrega falla.',
+            'rejection_reason_id.exists' => 'El motivo de rechazo no es válido.',
+            'items.required' => 'Los items son obligatorios.',
+            'items.*.route_stop_item_id.required' => 'El ID del item es obligatorio.',
+            'items.*.route_stop_item_id.exists' => 'Uno o más items no existen.',
+            'items.*.quantity_delivered.required' => 'La cantidad entregada es obligatoria.',
+            'items.*.quantity_delivered.integer' => 'La cantidad debe ser un número entero.',
+            'items.*.quantity_delivered.min' => 'La cantidad entregada no puede ser negativa.',
+            'items.*.rejection_reason_id.exists' => 'El motivo de rechazo no es válido.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Resources/RouteStopResource.php
+++ b/app/Http/Resources/RouteStopResource.php
@@ -47,6 +47,10 @@ class RouteStopResource extends JsonResource
             ]),
             'created_at' => $this->created_at?->format('Y-m-d H:i:s'),
             'updated_at' => $this->updated_at?->format('Y-m-d H:i:s'),
+            'items' => RouteStopItemResource::collection($this->whenLoaded('items')),
+            'completed_at' => $this->completed_at?->format('Y-m-d H:i:s'),
+            'gps_lat' => $this->gps_lat,
+            'gps_lon' => $this->gps_lon,
         ];
     }
 }

--- a/app/Models/DeliveryRejectionReason.php
+++ b/app/Models/DeliveryRejectionReason.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DeliveryRejectionReason extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'store_id',
+        'code',
+        'label',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function scopeGlobal(Builder $query): Builder
+    {
+        return $query->whereNull('store_id');
+    }
+
+    public function scopeForStore(Builder $query, string $storeId): Builder
+    {
+        return $query->whereNull('store_id')
+            ->orWhere('store_id', $storeId);
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/app/Models/RouteStop.php
+++ b/app/Models/RouteStop.php
@@ -25,6 +25,10 @@ class RouteStop extends Model
         'logistics_notes',
         'estimated_arrival_at',
         'travel_duration_seconds',
+        'completed_by',
+        'completed_at',
+        'gps_lat',
+        'gps_lon',
     ];
 
     protected function casts(): array
@@ -32,6 +36,9 @@ class RouteStop extends Model
         return [
             'estimated_arrival_at' => 'datetime',
             'travel_duration_seconds' => 'integer',
+            'completed_at' => 'datetime',
+            'gps_lat' => 'decimal:7',
+            'gps_lon' => 'decimal:7',
         ];
     }
 
@@ -48,6 +55,11 @@ class RouteStop extends Model
     public function items(): HasMany
     {
         return $this->hasMany(RouteStopItem::class, 'route_stop_id');
+    }
+
+    public function completedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'completed_by');
     }
 
     public function scopeActive(Builder $query): Builder

--- a/app/OpenApi/Schemas/Driver/DriverActiveRouteSchema.php
+++ b/app/OpenApi/Schemas/Driver/DriverActiveRouteSchema.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\OpenApi\Schemas\Driver;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'DriverActiveRoute',
+    title: 'DriverActiveRoute',
+    description: 'Ruta activa del conductor con vehiculo, conductor y paradas'
+)]
+class DriverActiveRouteSchema
+{
+    #[OA\Property(format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')]
+    public string $id;
+
+    #[OA\Property(example: 'dispatched', enum: ['draft', 'planned', 'dispatched', 'cancelled'])]
+    public string $status;
+
+    #[OA\Property(ref: '#/components/schemas/VehicleResource')]
+    public object $vehicle;
+
+    #[OA\Property(ref: '#/components/schemas/DriverResource')]
+    public object $driver;
+
+    #[OA\Property(
+        type: 'array',
+        items: new OA\Items(
+            properties: [
+                new OA\Property(property: 'id', type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440010'),
+                new OA\Property(property: 'sequence', type: 'integer', example: 1),
+                new OA\Property(property: 'status', type: 'string', example: 'pending'),
+                new OA\Property(property: 'client', type: 'object', properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Juan Pérez'),
+                    new OA\Property(property: 'address', type: 'string', example: 'Av. Corrientes 1234, CABA'),
+                ]),
+                new OA\Property(property: 'items', type: 'array', items: new OA\Items(
+                    properties: [
+                        new OA\Property(property: 'product_name', type: 'string', example: 'Leche entera 1L'),
+                        new OA\Property(property: 'quantity_loaded', type: 'integer', example: 10),
+                        new OA\Property(property: 'quantity_delivered', type: 'integer', example: 0),
+                    ],
+                    type: 'object'
+                )),
+            ],
+            type: 'object'
+        )
+    )]
+    public array $stops;
+}

--- a/app/Services/DriverExecutionService.php
+++ b/app/Services/DriverExecutionService.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DeliveryRoute;
+use App\Models\DeliveryRouteEvent;
+use App\Models\RouteStop;
+use App\Models\RouteStopItem;
+use App\Models\User;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\DB;
+
+class DriverExecutionService
+{
+    /**
+     * Find the active (dispatched) route for a driver.
+     * Returns null when no dispatched route exists for this driver.
+     */
+    public function getActiveRoute(User $driver): ?DeliveryRoute
+    {
+        return DeliveryRoute::where('driver_id', $driver->id)
+            ->where('store_id', $driver->store_id)
+            ->where('status', 'dispatched')
+            ->with([
+                'vehicle',
+                'stops' => function ($query) {
+                    $query->where('status', '!=', 'cancelled')
+                        ->orderBy('sequence');
+                },
+                'stops.items.product',
+                'stops.order.customer',
+            ])
+            ->first();
+    }
+
+    /**
+     * Mark arrival at a stop, optionally recording GPS coordinates.
+     */
+    public function arriveStop(RouteStop $stop, array $data, User $driver): RouteStop
+    {
+        $route = $this->validateDriverRoute($stop, $driver);
+
+        $stop->update([
+            'gps_lat' => $data['gps_lat'] ?? null,
+            'gps_lon' => $data['gps_lon'] ?? null,
+        ]);
+
+        return $stop->fresh();
+    }
+
+    /**
+     * Complete a stop delivery. Handles full, partial, and failed deliveries.
+     * Also checks if all stops are resolved and transitions the route.
+     */
+    public function completeStop(RouteStop $stop, array $data, User $driver): RouteStop
+    {
+        return DB::transaction(function () use ($stop, $data, $driver) {
+            $route = $this->validateDriverRoute($stop, $driver);
+
+            // Lock the stop to prevent race conditions
+            $stop = RouteStop::where('id', $stop->id)->lockForUpdate()->first();
+
+            if ($stop->status !== 'pending') {
+                throw $this->validationError('Este stop ya fue procesado.');
+            }
+
+            $items = $data['items'];
+            $allZero = true;
+
+            foreach ($items as $itemData) {
+                $routeStopItem = RouteStopItem::where('id', $itemData['route_stop_item_id'])
+                    ->where('route_stop_id', $stop->id)
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $routeStopItem) {
+                    throw $this->validationError("El item {$itemData['route_stop_item_id']} no pertenece a este stop.");
+                }
+
+                $qtyDelivered = (int) $itemData['quantity_delivered'];
+
+                if ($qtyDelivered > $routeStopItem->quantity_loaded) {
+                    throw $this->validationError(
+                        "La cantidad entregada ({$qtyDelivered}) no puede superar la cargada ({$routeStopItem->quantity_loaded})."
+                    );
+                }
+
+                // Partial delivery (some delivered, some not) requires a per-item rejection reason
+                if ($qtyDelivered > 0 && $qtyDelivered < $routeStopItem->quantity_loaded) {
+                    if (empty($itemData['rejection_reason_id'])) {
+                        throw $this->validationError(
+                            'Se requiere un motivo de rechazo cuando la cantidad entregada es menor a la cargada.'
+                        );
+                    }
+                }
+
+                if ($qtyDelivered > 0) {
+                    $allZero = false;
+                }
+
+                $routeStopItem->update([
+                    'quantity_delivered' => $qtyDelivered,
+                ]);
+            }
+
+            if ($allZero) {
+                if (empty($data['rejection_reason_id'])) {
+                    throw $this->validationError(
+                        'Se requiere un motivo de rechazo cuando no se entrega ningún producto.'
+                    );
+                }
+            }
+
+            // Determine final status
+            $finalStatus = $allZero ? 'failed' : 'completed';
+
+            $stop->update([
+                'status' => $finalStatus,
+                'completed_by' => $driver->id,
+                'completed_at' => now(),
+                'gps_lat' => $data['gps_lat'] ?? null,
+                'gps_lon' => $data['gps_lon'] ?? null,
+            ]);
+
+            // Create event
+            $eventType = $finalStatus === 'completed' ? 'stop_completed' : 'stop_failed';
+
+            $this->createEvent(
+                $route,
+                $route->store_id,
+                $driver->id,
+                $eventType,
+                'pending',
+                $finalStatus,
+                null,
+                [
+                    'stop_id' => $stop->id,
+                    'items' => $items,
+                    'rejection_reason_id' => $data['rejection_reason_id'] ?? null,
+                ]
+            );
+
+            // Check if all stops are now resolved
+            $this->checkAndTransitionRoute($route);
+
+            return $stop->fresh();
+        });
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────
+
+    /**
+     * Validate that the stop belongs to a dispatched route assigned to the driver.
+     * Returns the route if valid, throws otherwise.
+     */
+    private function validateDriverRoute(RouteStop $stop, User $driver): DeliveryRoute
+    {
+        $route = DeliveryRoute::with('stops')
+            ->where('id', $stop->route_id)
+            ->where('driver_id', $driver->id)
+            ->where('store_id', $driver->store_id)
+            ->first();
+
+        if (! $route) {
+            throw $this->notFoundError('No se encontró una ruta activa para este conductor y stop.');
+        }
+
+        if ($route->status !== 'dispatched') {
+            throw $this->notFoundError('La ruta no está en estado despachado.');
+        }
+
+        return $route;
+    }
+
+    /**
+     * Check if all active stops are completed or failed, transition route if so.
+     */
+    private function checkAndTransitionRoute(DeliveryRoute $route): void
+    {
+        $pendingCount = RouteStop::where('route_id', $route->id)
+            ->whereNotIn('status', ['completed', 'failed', 'cancelled'])
+            ->count();
+
+        if ($pendingCount === 0) {
+            $route->update(['status' => 'awaiting_reconciliation']);
+
+            $this->createEvent(
+                $route,
+                $route->store_id,
+                $route->driver_id,
+                'route_awaiting_reconciliation',
+                'dispatched',
+                'awaiting_reconciliation'
+            );
+        }
+    }
+
+    /**
+     * Create an immutable event record.
+     */
+    private function createEvent(
+        DeliveryRoute $route,
+        string $storeId,
+        string $userId,
+        string $eventType,
+        ?string $fromStatus = null,
+        ?string $toStatus = null,
+        ?string $reason = null,
+        ?array $metadata = null
+    ): DeliveryRouteEvent {
+        return DeliveryRouteEvent::create([
+            'store_id' => $storeId,
+            'route_id' => $route->id,
+            'user_id' => $userId,
+            'event_type' => $eventType,
+            'from_status' => $fromStatus,
+            'to_status' => $toStatus,
+            'reason' => $reason,
+            'metadata' => $metadata,
+        ]);
+    }
+
+    /**
+     * Build a validation error response (422).
+     */
+    private function validationError(string $message): HttpResponseException
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => $message,
+                'data' => null,
+                'errors' => ['error' => [$message]],
+            ], 422)
+        );
+    }
+
+    /**
+     * Build a not found error response (404).
+     */
+    private function notFoundError(string $message): HttpResponseException
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => $message,
+                'data' => null,
+                'errors' => ['error' => [$message]],
+            ], 404)
+        );
+    }
+}

--- a/database/factories/RouteStopFactory.php
+++ b/database/factories/RouteStopFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CommercialOperation;
+use App\Models\DeliveryRoute;
+use App\Models\RouteStop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RouteStop>
+ */
+class RouteStopFactory extends Factory
+{
+    protected $model = RouteStop::class;
+
+    public function definition(): array
+    {
+        return [
+            'route_id' => DeliveryRoute::factory(),
+            'order_id' => CommercialOperation::factory(),
+            'sequence' => $this->faker->numberBetween(1, 20),
+            'status' => 'pending',
+            'logistics_notes' => null,
+        ];
+    }
+
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'pending',
+        ]);
+    }
+
+    public function completed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'completed',
+        ]);
+    }
+
+    public function cancelled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'cancelled',
+        ]);
+    }
+}

--- a/database/migrations/2026_07_30_000001_add_driver_execution_columns_to_route_stops_table.php
+++ b/database/migrations/2026_07_30_000001_add_driver_execution_columns_to_route_stops_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('route_stops', function (Blueprint $table) {
+            $table->uuid('completed_by')->nullable()->after('travel_duration_seconds');
+            $table->timestamp('completed_at')->nullable()->after('completed_by');
+            $table->decimal('gps_lat', 10, 7)->nullable()->after('completed_at');
+            $table->decimal('gps_lon', 10, 7)->nullable()->after('gps_lat');
+
+            $table->foreign('completed_by')
+                ->references('id')
+                ->on('users')
+                ->onDelete('restrict');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('route_stops', function (Blueprint $table) {
+            $table->dropForeign(['completed_by']);
+            $table->dropColumn(['completed_by', 'completed_at', 'gps_lat', 'gps_lon']);
+        });
+    }
+};

--- a/database/migrations/2026_07_30_000002_create_delivery_rejection_reasons_table.php
+++ b/database/migrations/2026_07_30_000002_create_delivery_rejection_reasons_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('delivery_rejection_reasons', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('store_id')->nullable();
+            $table->string('code');
+            $table->string('label');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->foreign('store_id')
+                ->references('id')
+                ->on('stores')
+                ->onDelete('cascade');
+
+            $table->index('store_id');
+            $table->index('code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('delivery_rejection_reasons');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
       \Database\Seeders\SuperAdminPermissionsSeeder::class,
       \Database\Seeders\Geography\ProvinceSeeder::class,
       \Database\Seeders\Geography\LocalitySeeder::class,
+      \Database\Seeders\DeliveryRejectionReasonSeeder::class,
     ]);
 
 

--- a/database/seeders/DeliveryRejectionReasonSeeder.php
+++ b/database/seeders/DeliveryRejectionReasonSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\DeliveryRejectionReason;
+use Illuminate\Database\Seeder;
+
+class DeliveryRejectionReasonSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $reasons = [
+            ['code' => 'cliente_ausente', 'label' => 'Cliente ausente'],
+            ['code' => 'producto_danado', 'label' => 'Producto dañado'],
+            ['code' => 'error_pedido', 'label' => 'Error en pedido / producto equivocado'],
+            ['code' => 'local_cerrado', 'label' => 'Local cerrado'],
+            ['code' => 'cliente_sin_espacio', 'label' => 'Cliente sin espacio'],
+            ['code' => 'otros', 'label' => 'Otros'],
+        ];
+
+        foreach ($reasons as $reason) {
+            DeliveryRejectionReason::firstOrCreate(
+                ['code' => $reason['code'], 'store_id' => null],
+                ['label' => $reason['label'], 'is_active' => true],
+            );
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\V1\Admin\StoreController;
 use App\Http\Controllers\Api\V1\Admin\UserController;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\CatalogsController;
+use App\Http\Controllers\Api\V1\Driver\DriverExecutionController;
 use App\Http\Controllers\Api\V1\GeocodingController;
 use App\Http\Controllers\Api\V1\Store\CashSessionController;
 use App\Http\Controllers\Api\V1\Store\CategoryController;
@@ -44,6 +45,13 @@ Route::prefix('v1')->group(function () {
         Route::post('logout', [AuthController::class, 'logout']);
         Route::get('me', [AuthController::class, 'me']);
         Route::post('geocoding/search', [GeocodingController::class, 'search'])->name('geocoding.search');
+    });
+
+    // Driver Execution API — authenticated drivers complete their assigned deliveries
+    Route::middleware(['auth:sanctum', 'role:STORE_DRIVER'])->prefix('driver')->group(function () {
+        Route::get('active-route', [DriverExecutionController::class, 'activeRoute']);
+        Route::post('stops/{stop}/arrive', [DriverExecutionController::class, 'arrive']);
+        Route::post('stops/{stop}/complete', [DriverExecutionController::class, 'complete']);
     });
 
     Route::prefix('admin')

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -7486,6 +7486,309 @@
                 ]
             }
         },
+        "/driver/active-route": {
+            "get": {
+                "tags": [
+                    "Driver"
+                ],
+                "summary": "Obtener ruta activa del conductor",
+                "description": "Get the active (dispatched) route for the authenticated driver.",
+                "operationId": "a482d5f5ff2bce4bf88c76bfbda0c447",
+                "responses": {
+                    "200": {
+                        "description": "Ruta activa obtenida exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/DriverActiveRoute"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "meta": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No se encontró una ruta despachada para este conductor.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "error"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "No se encontró una ruta activa para este conductor."
+                                        },
+                                        "data": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "error": [
+                                                    "No se encontró una ruta despachada para este conductor."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/driver/stops/{stop}/arrive": {
+            "post": {
+                "tags": [
+                    "Driver"
+                ],
+                "summary": "Registrar llegada a una parada",
+                "description": "Mark arrival at a stop, optionally recording GPS coordinates.",
+                "operationId": "457b246627f6aa6ea58093c110884f0b",
+                "parameters": [
+                    {
+                        "name": "stop",
+                        "in": "path",
+                        "description": "ID del RouteStop",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "gps_lat": {
+                                        "type": "number",
+                                        "example": -34.6037,
+                                        "nullable": true
+                                    },
+                                    "gps_lon": {
+                                        "type": "number",
+                                        "example": -58.3816,
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Llegada registrada exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/RouteStop"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "meta": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Conductor no asignado a esta parada"
+                    },
+                    "404": {
+                        "description": "Parada no encontrada"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/driver/stops/{stop}/complete": {
+            "post": {
+                "tags": [
+                    "Driver"
+                ],
+                "summary": "Completar entrega de una parada",
+                "description": "Complete a stop delivery with item-level quantities.",
+                "operationId": "aacfaad4cd48b090679cd774f775d497",
+                "parameters": [
+                    {
+                        "name": "stop",
+                        "in": "path",
+                        "description": "ID del RouteStop",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "status",
+                                    "items"
+                                ],
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "completed",
+                                            "failed"
+                                        ],
+                                        "example": "completed"
+                                    },
+                                    "gps_lat": {
+                                        "type": "number",
+                                        "example": -34.6037,
+                                        "nullable": true
+                                    },
+                                    "gps_lon": {
+                                        "type": "number",
+                                        "example": -58.3816,
+                                        "nullable": true
+                                    },
+                                    "rejection_reason_id": {
+                                        "description": "Requerido si status=failed",
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "nullable": true
+                                    },
+                                    "items": {
+                                        "type": "array",
+                                        "items": {
+                                            "required": [
+                                                "route_stop_item_id",
+                                                "quantity_delivered"
+                                            ],
+                                            "properties": {
+                                                "route_stop_item_id": {
+                                                    "type": "string",
+                                                    "format": "uuid",
+                                                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                                                },
+                                                "quantity_delivered": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                },
+                                                "rejection_reason_id": {
+                                                    "type": "string",
+                                                    "format": "uuid",
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Entrega completada exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/RouteStop"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "meta": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Conductor no asignado a esta parada"
+                    },
+                    "404": {
+                        "description": "Parada no encontrada"
+                    },
+                    "422": {
+                        "description": "Error de validación"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/geocoding/search": {
             "post": {
                 "tags": [
@@ -16333,6 +16636,88 @@
                 },
                 "type": "object"
             },
+            "DriverActiveRoute": {
+                "title": "DriverActiveRoute",
+                "description": "Ruta activa del conductor con vehiculo, conductor y paradas",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "draft",
+                            "planned",
+                            "dispatched",
+                            "cancelled"
+                        ],
+                        "example": "dispatched"
+                    },
+                    "vehicle": {
+                        "$ref": "#/components/schemas/VehicleResource"
+                    },
+                    "driver": {
+                        "$ref": "#/components/schemas/DriverResource"
+                    },
+                    "stops": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "example": "550e8400-e29b-41d4-a716-446655440010"
+                                },
+                                "sequence": {
+                                    "type": "integer",
+                                    "example": 1
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "example": "pending"
+                                },
+                                "client": {
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "example": "Juan Pérez"
+                                        },
+                                        "address": {
+                                            "type": "string",
+                                            "example": "Av. Corrientes 1234, CABA"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "product_name": {
+                                                "type": "string",
+                                                "example": "Leche entera 1L"
+                                            },
+                                            "quantity_loaded": {
+                                                "type": "integer",
+                                                "example": 10
+                                            },
+                                            "quantity_delivered": {
+                                                "type": "integer",
+                                                "example": 0
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "GeocodingResult": {
                 "title": "GeocodingResult",
                 "description": "Resultado de la geocodificación de una dirección",
@@ -17694,6 +18079,10 @@
         {
             "name": "Catálogos",
             "description": "Catálogos"
+        },
+        {
+            "name": "Driver",
+            "description": "Driver"
         },
         {
             "name": "Geocoding",

--- a/tests/Feature/Api/V1/Driver/DriverExecutionTest.php
+++ b/tests/Feature/Api/V1/Driver/DriverExecutionTest.php
@@ -1,0 +1,564 @@
+<?php
+
+use App\Models\DeliveryRejectionReason;
+use App\Models\DeliveryRoute;
+use App\Models\DeliveryRouteEvent;
+use App\Models\Feature;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\RouteStop;
+use App\Models\RouteStopItem;
+use App\Models\Store;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_DRIVER', 'guard_name' => 'web']);
+
+    $this->store = Store::factory()->create();
+
+    $plan = Plan::factory()->create();
+    $dFeature = Feature::create(['code' => 'deliveries', 'name' => 'Entregas']);
+    $plan->features()->attach($dFeature->id);
+    $this->store->update(['plan_id' => $plan->id]);
+
+    $this->vehicle = Vehicle::factory()->create(['store_id' => $this->store->id]);
+
+    // Create driver user
+    $this->driver = User::factory()->create(['store_id' => $this->store->id]);
+    $this->driver->assignRole('STORE_DRIVER');
+    $this->driverToken = $this->driver->createToken('driver-test')->plainTextToken;
+
+    // Create non-driver user
+    $this->nonDriver = User::factory()->create(['store_id' => $this->store->id]);
+    $this->nonDriver->assignRole('STORE_ADMIN');
+    $this->nonDriverToken = $this->nonDriver->createToken('admin-test')->plainTextToken;
+
+    // Seed rejection reasons
+    $this->seed(\Database\Seeders\DeliveryRejectionReasonSeeder::class);
+});
+
+// ─── Helper: create a dispatched route with stops and items ────────────────
+
+function createDispatchedRoute(User $driver, Store $store, Vehicle $vehicle): array
+{
+    $route = DeliveryRoute::factory()->create([
+        'store_id' => $store->id,
+        'vehicle_id' => $vehicle->id,
+        'driver_id' => $driver->id,
+        'status' => 'dispatched',
+        'dispatched_at' => now(),
+    ]);
+
+    $product1 = Product::factory()->create(['store_id' => $store->id]);
+    $product2 = Product::factory()->create(['store_id' => $store->id]);
+
+    $stop1 = RouteStop::factory()->create([
+        'route_id' => $route->id,
+        'sequence' => 1,
+        'status' => 'pending',
+    ]);
+
+    $stop2 = RouteStop::factory()->create([
+        'route_id' => $route->id,
+        'sequence' => 2,
+        'status' => 'pending',
+    ]);
+
+    $stopItem1 = RouteStopItem::factory()->create([
+        'route_stop_id' => $stop1->id,
+        'product_id' => $product1->id,
+        'quantity_planned' => 10,
+        'quantity_loaded' => 10,
+        'quantity_delivered' => 0,
+    ]);
+
+    $stopItem2 = RouteStopItem::factory()->create([
+        'route_stop_id' => $stop1->id,
+        'product_id' => $product2->id,
+        'quantity_planned' => 5,
+        'quantity_loaded' => 5,
+        'quantity_delivered' => 0,
+    ]);
+
+    $stopItem3 = RouteStopItem::factory()->create([
+        'route_stop_id' => $stop2->id,
+        'product_id' => $product1->id,
+        'quantity_planned' => 3,
+        'quantity_loaded' => 3,
+        'quantity_delivered' => 0,
+    ]);
+
+    return [
+        'route' => $route,
+        'stops' => [$stop1, $stop2],
+        'items' => [$stopItem1, $stopItem2, $stopItem3],
+    ];
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: GET /api/v1/driver/active-route
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('active route returns dispatched route for assigned driver', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.id', $data['route']->id)
+        ->assertJsonPath('data.status', 'dispatched')
+        ->assertJsonPath('data.stops.0.id', $data['stops'][0]->id)
+        ->assertJsonPath('data.stops.1.id', $data['stops'][1]->id);
+});
+
+test('active route returns 404 when driver has no dispatched route', function () {
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(404);
+});
+
+test('active route ignores driver route with non-dispatched status', function () {
+    DeliveryRoute::factory()->create([
+        'store_id' => $this->store->id,
+        'vehicle_id' => $this->vehicle->id,
+        'driver_id' => $this->driver->id,
+        'status' => 'loaded',
+    ]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(404);
+});
+
+test('active route returns 403 for non-driver user', function () {
+    $response = $this->withHeader('Authorization', "Bearer {$this->nonDriverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(403);
+});
+
+test('active route loads vehicle, stops, items, and customer relations', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.vehicle.id', $this->vehicle->id)
+        ->assertJsonPath('data.stops.0.items.0.id', $data['items'][0]->id);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: POST /api/v1/driver/stops/{stop}/arrive
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('arrive records gps coordinates on stop', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/arrive", [
+            'gps_lat' => -34.6037,
+            'gps_lon' => -58.3816,
+        ]);
+
+    $response->assertStatus(200);
+
+    $this->assertDatabaseHas('route_stops', [
+        'id' => $stop->id,
+        'gps_lat' => -34.6037000,
+        'gps_lon' => -58.3816000,
+    ]);
+});
+
+test('arrive works without gps coordinates', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/arrive", []);
+
+    $response->assertStatus(200);
+});
+
+test('arrive returns 403 for non-driver', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->nonDriverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/arrive", [
+            'gps_lat' => -34.6037,
+            'gps_lon' => -58.3816,
+        ]);
+
+    $response->assertStatus(403);
+});
+
+test('arrive returns 404 when stop belongs to different driver route', function () {
+    createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+
+    // Create another driver and route
+    $otherDriver = User::factory()->create(['store_id' => $this->store->id]);
+    $otherDriver->assignRole('STORE_DRIVER');
+    $otherData = createDispatchedRoute($otherDriver, $this->store, $this->vehicle);
+    $otherStop = $otherData['stops'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$otherStop->id}/arrive", []);
+
+    $response->assertStatus(404);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: POST /api/v1/driver/stops/{stop}/complete — full delivery
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('complete stop delivers full quantities and sets completed status', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+    $item2 = $data['items'][1];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'gps_lat' => -34.6037,
+            'gps_lon' => -58.3816,
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $item2->id, 'quantity_delivered' => 5],
+            ],
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'completed');
+
+    $this->assertDatabaseHas('route_stops', [
+        'id' => $stop->id,
+        'status' => 'completed',
+        'completed_by' => $this->driver->id,
+        'gps_lat' => -34.6037000,
+        'gps_lon' => -58.3816000,
+    ]);
+    $this->assertNotNull(RouteStop::find($stop->id)->completed_at);
+
+    $this->assertDatabaseHas('route_stop_items', [
+        'id' => $item1->id,
+        'quantity_delivered' => 10,
+    ]);
+    $this->assertDatabaseHas('route_stop_items', [
+        'id' => $item2->id,
+        'quantity_delivered' => 5,
+    ]);
+
+    // Event created
+    $this->assertDatabaseHas('delivery_route_events', [
+        'route_id' => $data['route']->id,
+        'event_type' => 'stop_completed',
+        'user_id' => $this->driver->id,
+    ]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: POST /api/v1/driver/stops/{stop}/complete — partial delivery
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('complete stop with partial delivery and rejection reasons', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+    $item2 = $data['items'][1];
+
+    $reason = DeliveryRejectionReason::where('code', 'cliente_ausente')->first();
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'gps_lat' => -34.6037,
+            'gps_lon' => -58.3816,
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $item2->id, 'quantity_delivered' => 3, 'rejection_reason_id' => $reason->id],
+            ],
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'completed');
+
+    $this->assertDatabaseHas('route_stop_items', [
+        'id' => $item2->id,
+        'quantity_delivered' => 3,
+    ]);
+});
+
+test('complete stop rejects partial delivery without rejection_reason_id', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 3],
+            ],
+        ]);
+
+    // Should fail: partial delivery without reason
+    $response->assertStatus(422);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: POST /api/v1/driver/stops/{stop}/complete — failed delivery
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('complete stop with zero delivered is failed and requires rejection_reason_id', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+    $item2 = $data['items'][1];
+
+    $reason = DeliveryRejectionReason::where('code', 'cliente_ausente')->first();
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'failed',
+            'rejection_reason_id' => $reason->id,
+            'gps_lat' => -34.6037,
+            'gps_lon' => -58.3816,
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 0],
+                ['route_stop_item_id' => $item2->id, 'quantity_delivered' => 0],
+            ],
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'failed');
+
+    $this->assertDatabaseHas('route_stops', [
+        'id' => $stop->id,
+        'status' => 'failed',
+    ]);
+
+    // Event created
+    $this->assertDatabaseHas('delivery_route_events', [
+        'route_id' => $data['route']->id,
+        'event_type' => 'stop_failed',
+    ]);
+});
+
+test('complete stop failed without rejection_reason_id returns validation error', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'failed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 0],
+            ],
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('errors.rejection_reason_id.0', fn ($v) => str_contains($v, 'obligatorio'));
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: Validation / edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('complete stop rejects quantity_delivered exceeding quantity_loaded', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0]; // quantity_loaded = 10
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 11],
+            ],
+        ]);
+
+    $response->assertStatus(422);
+});
+
+test('complete stop rejects already completed stop', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+    $item2 = $data['items'][1];
+
+    // Complete the stop first
+    $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $item2->id, 'quantity_delivered' => 5],
+            ],
+        ]);
+
+    // Try to complete again
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $item2->id, 'quantity_delivered' => 5],
+            ],
+        ]);
+
+    $response->assertStatus(422);
+});
+
+test('complete stop returns 404 when driver not assigned to route', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+
+    // Another driver tries to complete
+    $otherDriver = User::factory()->create(['store_id' => $this->store->id]);
+    $otherDriver->assignRole('STORE_DRIVER');
+    $otherToken = $otherDriver->createToken('other-test')->plainTextToken;
+
+    $response = $this->withHeader('Authorization', "Bearer {$otherToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 10],
+            ],
+        ]);
+
+    $response->assertStatus(404);
+});
+
+test('complete stop returns 404 when route is not dispatched', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+
+    // Change route to loaded
+    $data['route']->update(['status' => 'loaded']);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 10],
+            ],
+        ]);
+
+    $response->assertStatus(404);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: Auto-transition to awaiting_reconciliation
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('completing last stop transitions route to awaiting_reconciliation', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop1 = $data['stops'][0];
+    $stop2 = $data['stops'][1];
+
+    $itemsStop1 = RouteStopItem::where('route_stop_id', $stop1->id)->get();
+    $itemsStop2 = RouteStopItem::where('route_stop_id', $stop2->id)->get();
+
+    // Complete first stop
+    $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop1->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $itemsStop1[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $itemsStop1[1]->id, 'quantity_delivered' => 5],
+            ],
+        ])->assertStatus(200);
+
+    // Route should still be dispatched
+    $this->assertEquals('dispatched', $data['route']->fresh()->status);
+
+    // Complete second (last) stop
+    $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop2->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $itemsStop2[0]->id, 'quantity_delivered' => 3],
+            ],
+        ])->assertStatus(200);
+
+    // Route should be awaiting_reconciliation
+    $this->assertEquals('awaiting_reconciliation', $data['route']->fresh()->status);
+
+    $this->assertDatabaseHas('delivery_route_events', [
+        'route_id' => $data['route']->id,
+        'event_type' => 'route_awaiting_reconciliation',
+    ]);
+});
+
+test('transition awaits all stops when mix of completed and failed', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop1 = $data['stops'][0];
+    $stop2 = $data['stops'][1];
+    $reason = DeliveryRejectionReason::where('code', 'cliente_ausente')->first();
+
+    $itemsStop1 = RouteStopItem::where('route_stop_id', $stop1->id)->get();
+    $itemsStop2 = RouteStopItem::where('route_stop_id', $stop2->id)->get();
+
+    // Complete first stop normally
+    $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop1->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $itemsStop1[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $itemsStop1[1]->id, 'quantity_delivered' => 5],
+            ],
+        ])->assertStatus(200);
+
+    // Fail second stop
+    $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop2->id}/complete", [
+            'status' => 'failed',
+            'rejection_reason_id' => $reason->id,
+            'items' => [
+                ['route_stop_item_id' => $itemsStop2[0]->id, 'quantity_delivered' => 0],
+            ],
+        ])->assertStatus(200);
+
+    $this->assertEquals('awaiting_reconciliation', $data['route']->fresh()->status);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS: Rejection reasons
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('rejection_reason_id must reference an existing reason', function () {
+    $data = createDispatchedRoute($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $item1 = $data['items'][0];
+    $item2 = $data['items'][1];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'failed',
+            'rejection_reason_id' => '00000000-0000-0000-0000-000000000000',
+            'items' => [
+                ['route_stop_item_id' => $item1->id, 'quantity_delivered' => 0],
+                ['route_stop_item_id' => $item2->id, 'quantity_delivered' => 0],
+            ],
+        ]);
+
+    $response->assertStatus(422);
+});


### PR DESCRIPTION
feat: Create migration to add driver execution columns to route_stops table

feat: Create migration for delivery_rejection_reasons table

feat: Update DatabaseSeeder to include DeliveryRejectionReasonSeeder

feat: Implement DeliveryRejectionReasonSeeder for seeding rejection reasons

feat: Add driver execution routes for managing delivery stops

docs: Update API documentation for new driver execution endpoints

test: Implement tests for driver execution features including active route, stop arrival, and delivery completion