### PR TITLE
feat: add total amount, paid amount, and pending balance attributes to CommercialOperation model

### DIFF
--- a/app/Http/Controllers/Api/V1/Driver/DriverExecutionController.php
+++ b/app/Http/Controllers/Api/V1/Driver/DriverExecutionController.php
@@ -5,201 +5,240 @@ namespace App\Http\Controllers\Api\V1\Driver;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Driver\CompleteStopRequest;
 use App\Http\Resources\DeliveryRouteResource;
+use App\Http\Resources\DriverPaymentMethodResource;
 use App\Http\Resources\RouteStopResource;
 use App\Models\RouteStop;
+use App\Models\StorePaymentMethod;
 use App\Services\DriverExecutionService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class DriverExecutionController extends Controller
 {
-    public function __construct(
-        private readonly DriverExecutionService $executionService,
-    ) {}
+  public function __construct(
+    private readonly DriverExecutionService $executionService,
+  ) {}
 
-    /**
-     * Get the active (dispatched) route for the authenticated driver.
-     *
-     * @OA\Get(
-     *   path="/driver/active-route",
-     *   summary="Obtener ruta activa del conductor",
-     *   tags={"Driver"},
-     *   security={{"sanctum":{}}},
-     *
-     *   @OA\Response(
-     *     response=200,
-     *     description="Ruta activa obtenida exitosamente",
-     *
-     *     @OA\JsonContent(
-     *
-     *       @OA\Property(property="status", type="string", example="success"),
-     *       @OA\Property(property="message", type="null", example=null),
-     *       @OA\Property(property="data", ref="#/components/schemas/DriverActiveRoute"),
-     *       @OA\Property(property="errors", type="null", example=null),
-     *       @OA\Property(property="meta", type="null", example=null)
-     *     )
-     *   ),
-     *
-     *   @OA\Response(
-     *     response=404,
-     *     description="No se encontró una ruta despachada para este conductor.",
-     *
-     *     @OA\JsonContent(
-     *
-     *       @OA\Property(property="status", type="string", example="error"),
-     *       @OA\Property(property="message", type="string", example="No se encontró una ruta activa para este conductor."),
-     *       @OA\Property(property="data", type="null", example=null),
-     *       @OA\Property(property="errors", type="object", example={"error": {"No se encontró una ruta despachada para este conductor."}})
-     *     )
-     *   )
-     * )
-     */
-    public function activeRoute(Request $request): JsonResponse
-    {
-        $driver = $request->user();
-        $route = $this->executionService->getActiveRoute($driver);
+  /**
+   * Get the active (dispatched) route for the authenticated driver.
+   *
+   * @OA\Get(
+   *   path="/driver/active-route",
+   *   summary="Obtener ruta activa del conductor",
+   *   tags={"Driver"},
+   *   security={{"sanctum":{}}},
+   *
+   *   @OA\Response(
+   *     response=200,
+   *     description="Ruta activa obtenida exitosamente",
+   *
+   *     @OA\JsonContent(
+   *
+   *       @OA\Property(property="status", type="string", example="success"),
+   *       @OA\Property(property="message", type="null", example=null),
+   *       @OA\Property(
+   *         property="data",
+   *         type="object",
+   *         @OA\Property(property="route", ref="#/components/schemas/DeliveryRoute"),
+   *         @OA\Property(
+   *           property="available_payment_methods",
+   *           type="array",
+   *
+   *           @OA\Items(ref="#/components/schemas/DriverPaymentMethod")
+   *         )
+   *       ),
+   *       @OA\Property(property="errors", type="null", example=null),
+   *       @OA\Property(property="meta", type="null", example=null)
+   *     )
+   *   ),
+   *
+   *   @OA\Response(
+   *     response=404,
+   *     description="No se encontró una ruta despachada para este conductor.",
+   *
+   *     @OA\JsonContent(
+   *
+   *       @OA\Property(property="status", type="string", example="error"),
+   *       @OA\Property(property="message", type="string", example="No se encontró una ruta activa para este conductor."),
+   *       @OA\Property(property="data", type="null", example=null),
+   *       @OA\Property(property="errors", type="object", example={"error": {"No se encontró una ruta despachada para este conductor."}})
+   *     )
+   *   )
+   * )
+   */
+  public function activeRoute(Request $request): JsonResponse
+  {
+    $driver = $request->user();
+    $route = $this->executionService->getActiveRoute($driver);
 
-        if (! $route) {
-            return response()->json([
-                'status' => 'error',
-                'message' => 'No se encontró una ruta activa para este conductor.',
-                'data' => null,
-                'errors' => ['error' => ['No se encontró una ruta despachada para este conductor.']],
-            ], 404);
-        }
-
-        return response()->json([
-            'status' => 'success',
-            'message' => null,
-            'data' => DeliveryRouteResource::make($route),
-            'errors' => null,
-            'meta' => null,
-        ]);
+    if (! $route) {
+      return response()->json([
+        'status' => 'error',
+        'message' => 'No se encontró una ruta activa para este conductor.',
+        'data' => null,
+        'errors' => ['error' => ['No se encontró una ruta despachada para este conductor.']],
+      ], 404);
     }
 
-    /**
-     * Mark arrival at a stop, optionally recording GPS coordinates.
-     *
-     * @OA\Post(
-     *   path="/driver/stops/{stop}/arrive",
-     *   summary="Registrar llegada a una parada",
-     *   tags={"Driver"},
-     *   security={{"sanctum":{}}},
-     *
-     *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
-     *
-     *   @OA\RequestBody(
-     *     required=false,
-     *
-     *     @OA\JsonContent(
-     *
-     *       @OA\Property(property="gps_lat", type="number", example=-34.6037, nullable=true),
-     *       @OA\Property(property="gps_lon", type="number", example=-58.3816, nullable=true)
-     *     )
-     *   ),
-     *
-     *   @OA\Response(
-     *     response=200,
-     *     description="Llegada registrada exitosamente",
-     *
-     *     @OA\JsonContent(
-     *
-     *       @OA\Property(property="status", type="string", example="success"),
-     *       @OA\Property(property="message", type="null", example=null),
-     *       @OA\Property(property="data", ref="#/components/schemas/RouteStop"),
-     *       @OA\Property(property="errors", type="null", example=null),
-     *       @OA\Property(property="meta", type="null", example=null)
-     *     )
-     *   ),
-     *
-     *   @OA\Response(response=403, description="Conductor no asignado a esta parada"),
-     *   @OA\Response(response=404, description="Parada no encontrada")
-     * )
-     */
-    public function arrive(Request $request, string $stopId): JsonResponse
-    {
-        $driver = $request->user();
-        $stop = RouteStop::findOrFail($stopId);
+    $availablePaymentMethods = StorePaymentMethod::forStore($driver->store_id)
+      ->with('paymentMethod')
+      ->where('is_enabled', true)
+      ->get();
 
-        $stop = $this->executionService->arriveStop($stop, $request->only(['gps_lat', 'gps_lon']), $driver);
+    return response()->json([
+      'status' => 'success',
+      'message' => null,
+      'data' => [
+        'route' => DeliveryRouteResource::make($route),
+        'available_payment_methods' => DriverPaymentMethodResource::collection($availablePaymentMethods),
+      ],
+      'errors' => null,
+    ]);
+  }
 
-        return response()->json([
-            'status' => 'success',
-            'message' => null,
-            'data' => RouteStopResource::make($stop),
-            'errors' => null,
-            'meta' => null,
-        ]);
-    }
+  /**
+   * Mark arrival at a stop, optionally recording GPS coordinates.
+   *
+   * @OA\Post(
+   *   path="/driver/stops/{stop}/arrive",
+   *   summary="Registrar llegada a una parada",
+   *   tags={"Driver"},
+   *   security={{"sanctum":{}}},
+   *
+   *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
+   *
+   *   @OA\RequestBody(
+   *     required=false,
+   *
+   *     @OA\JsonContent(
+   *
+   *       @OA\Property(property="gps_lat", type="number", example=-34.6037, nullable=true),
+   *       @OA\Property(property="gps_lon", type="number", example=-58.3816, nullable=true)
+   *     )
+   *   ),
+   *
+   *   @OA\Response(
+   *     response=200,
+   *     description="Llegada registrada exitosamente",
+   *
+   *     @OA\JsonContent(
+   *
+   *       @OA\Property(property="status", type="string", example="success"),
+   *       @OA\Property(property="message", type="null", example=null),
+   *       @OA\Property(property="data", ref="#/components/schemas/RouteStop"),
+   *       @OA\Property(property="errors", type="null", example=null),
+   *       @OA\Property(property="meta", type="null", example=null)
+   *     )
+   *   ),
+   *
+   *   @OA\Response(response=403, description="Conductor no asignado a esta parada"),
+   *   @OA\Response(response=404, description="Parada no encontrada")
+   * )
+   */
+  public function arrive(Request $request, string $stopId): JsonResponse
+  {
+    $driver = $request->user();
+    $stop = RouteStop::findOrFail($stopId);
 
-    /**
-     * Complete a stop delivery with item-level quantities.
-     *
-     * @OA\Post(
-     *   path="/driver/stops/{stop}/complete",
-     *   summary="Completar entrega de una parada",
-     *   tags={"Driver"},
-     *   security={{"sanctum":{}}},
-     *
-     *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
-     *
-     *   @OA\RequestBody(
-     *     required=true,
-     *
-     *     @OA\JsonContent(
-     *       required={"status", "items"},
-     *
-     *       @OA\Property(property="status", type="string", enum={"completed", "failed"}, example="completed"),
-     *       @OA\Property(property="gps_lat", type="number", example=-34.6037, nullable=true),
-     *       @OA\Property(property="gps_lon", type="number", example=-58.3816, nullable=true),
-     *       @OA\Property(property="rejection_reason_id", type="string", format="uuid", nullable=true, description="Requerido si status=failed"),
-     *       @OA\Property(
-     *         property="items",
-     *         type="array",
-     *
-     *         @OA\Items(
-     *           required={"route_stop_item_id", "quantity_delivered"},
-     *
-     *           @OA\Property(property="route_stop_item_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
-     *           @OA\Property(property="quantity_delivered", type="integer", example=5),
-     *           @OA\Property(property="rejection_reason_id", type="string", format="uuid", nullable=true)
-     *         )
-     *       )
-     *     )
-     *   ),
-     *
-     *   @OA\Response(
-     *     response=200,
-     *     description="Entrega completada exitosamente",
-     *
-     *     @OA\JsonContent(
-     *
-     *       @OA\Property(property="status", type="string", example="success"),
-     *       @OA\Property(property="message", type="null", example=null),
-     *       @OA\Property(property="data", ref="#/components/schemas/RouteStop"),
-     *       @OA\Property(property="errors", type="null", example=null),
-     *       @OA\Property(property="meta", type="null", example=null)
-     *     )
-     *   ),
-     *
-     *   @OA\Response(response=403, description="Conductor no asignado a esta parada"),
-     *   @OA\Response(response=404, description="Parada no encontrada"),
-     *   @OA\Response(response=422, description="Error de validación")
-     * )
-     */
-    public function complete(CompleteStopRequest $request, string $stopId): JsonResponse
-    {
-        $driver = $request->user();
-        $stop = RouteStop::findOrFail($stopId);
+    $stop = $this->executionService->arriveStop($stop, $request->only(['gps_lat', 'gps_lon']), $driver);
 
-        $stop = $this->executionService->completeStop($stop, $request->validated(), $driver);
+    return response()->json([
+      'status' => 'success',
+      'message' => null,
+      'data' => RouteStopResource::make($stop),
+      'errors' => null,
+      'meta' => null,
+    ]);
+  }
 
-        return response()->json([
-            'status' => 'success',
-            'message' => null,
-            'data' => RouteStopResource::make($stop),
-            'errors' => null,
-            'meta' => null,
-        ]);
-    }
+  /**
+   * Complete a stop delivery with item-level quantities.
+   *
+   * @OA\Post(
+   *   path="/driver/stops/{stop}/complete",
+   *   summary="Completar entrega de una parada",
+   *   tags={"Driver"},
+   *   security={{"sanctum":{}}},
+   *
+   *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
+   *
+   *   @OA\RequestBody(
+   *     required=true,
+   *
+   *     @OA\JsonContent(
+   *       required={"status", "items"},
+   *
+   *       @OA\Property(property="status", type="string", enum={"completed", "failed"}, example="completed"),
+   *       @OA\Property(property="gps_lat", type="number", example=-34.6037, nullable=true),
+   *       @OA\Property(property="gps_lon", type="number", example=-58.3816, nullable=true),
+   *       @OA\Property(property="signature_uri", type="string", maxLength=500, nullable=true, example="https://cdn.example.com/signatures/img001.png"),
+   *       @OA\Property(
+   *         property="evidence_uris",
+   *         type="array",
+   *         nullable=true,
+   *
+   *         @OA\Items(type="string", example="https://cdn.example.com/evidence/img001.png")
+   *       ),
+   *       @OA\Property(property="rejection_reason_id", type="string", format="uuid", nullable=true, description="Requerido si status=failed"),
+   *       @OA\Property(
+   *         property="items",
+   *         type="array",
+   *
+   *         @OA\Items(
+   *           required={"route_stop_item_id", "quantity_delivered"},
+   *
+   *           @OA\Property(property="route_stop_item_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
+   *           @OA\Property(property="quantity_delivered", type="integer", example=5),
+   *           @OA\Property(property="rejection_reason_id", type="string", format="uuid", nullable=true)
+   *         )
+   *       ),
+   *       @OA\Property(
+   *         property="payments",
+   *         type="array",
+   *         nullable=true,
+   *
+   *         @OA\Items(
+   *
+   *           @OA\Property(property="store_payment_method_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
+   *           @OA\Property(property="amount", type="number", format="decimal", example=1500.00),
+   *           @OA\Property(property="reference", type="string", nullable=true, example="TRX-001234")
+   *         )
+   *       )
+   *     )
+   *   ),
+   *
+   *   @OA\Response(
+   *     response=200,
+   *     description="Entrega completada exitosamente",
+   *
+   *     @OA\JsonContent(
+   *
+   *       @OA\Property(property="status", type="string", example="success"),
+   *       @OA\Property(property="message", type="null", example=null),
+   *       @OA\Property(property="data", ref="#/components/schemas/RouteStop"),
+   *       @OA\Property(property="errors", type="null", example=null),
+   *       @OA\Property(property="meta", type="null", example=null)
+   *     )
+   *   ),
+   *
+   *   @OA\Response(response=403, description="Conductor no asignado a esta parada"),
+   *   @OA\Response(response=404, description="Parada no encontrada"),
+   *   @OA\Response(response=422, description="Error de validación")
+   * )
+   */
+  public function complete(CompleteStopRequest $request, string $stopId): JsonResponse
+  {
+    $driver = $request->user();
+    $stop = RouteStop::findOrFail($stopId);
+
+    $stop = $this->executionService->completeStop($stop, $request->validated(), $driver);
+
+    return response()->json([
+      'status' => 'success',
+      'message' => null,
+      'data' => RouteStopResource::make($stop),
+      'errors' => null,
+      'meta' => null,
+    ]);
+  }
 }

--- a/app/Http/Controllers/Api/V1/Store/RejectionReasonController.php
+++ b/app/Http/Controllers/Api/V1/Store/RejectionReasonController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Store;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\DeliveryRejectionReasonResource;
+use App\Models\DeliveryRejectionReason;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class RejectionReasonController extends Controller
+{
+    /**
+     * List active rejection reasons — global plus store-specific.
+     *
+     * @OA\Get(
+     *   path="/store/logistics/rejection-reasons",
+     *   summary="Listar motivos de rechazo",
+     *   tags={"Store - Logística"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Listado de motivos de rechazo",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="null", example=null),
+     *       @OA\Property(
+     *         property="data",
+     *         type="array",
+     *
+     *         @OA\Items(ref="#/components/schemas/RejectionReason")
+     *       ),
+     *       @OA\Property(property="errors", type="null", example=null),
+     *       @OA\Property(property="meta", type="null", example=null)
+     *     )
+     *   )
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $storeId = $request->user()->store_id;
+
+        $reasons = DeliveryRejectionReason::forStore($storeId)
+            ->where('is_active', true)
+            ->orderByRaw('store_id IS NULL DESC')
+            ->orderBy('label')
+            ->get();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => null,
+            'data' => DeliveryRejectionReasonResource::collection($reasons),
+            'errors' => null,
+            'meta' => null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/V1/Driver/CompleteStopRequest.php
+++ b/app/Http/Requests/Api/V1/Driver/CompleteStopRequest.php
@@ -19,6 +19,9 @@ class CompleteStopRequest extends FormRequest
             'status' => ['required', 'string', 'in:completed,failed'],
             'gps_lat' => ['nullable', 'numeric'],
             'gps_lon' => ['nullable', 'numeric'],
+            'signature_uri' => ['nullable', 'string', 'max:500'],
+            'evidence_uris' => ['nullable', 'array'],
+            'evidence_uris.*' => ['string'],
             'rejection_reason_id' => [
                 'required_if:status,failed',
                 'uuid',
@@ -40,6 +43,26 @@ class CompleteStopRequest extends FormRequest
                 'uuid',
                 'exists:delivery_rejection_reasons,id',
             ],
+            'payments' => ['nullable', 'array'],
+            'payments.*.store_payment_method_id' => [
+                'required',
+                'uuid',
+                'exists:store_payment_methods,id',
+            ],
+            'payments.*.amount' => [
+                'required',
+                'numeric',
+                'min:0.01',
+            ],
+            'payments.*.reference' => [
+                'nullable',
+                'string',
+                'max:255',
+            ],
+            'payments.*.notes' => [
+                'nullable',
+                'string',
+            ],
         ];
     }
 
@@ -57,6 +80,11 @@ class CompleteStopRequest extends FormRequest
             'items.*.quantity_delivered.integer' => 'La cantidad debe ser un número entero.',
             'items.*.quantity_delivered.min' => 'La cantidad entregada no puede ser negativa.',
             'items.*.rejection_reason_id.exists' => 'El motivo de rechazo no es válido.',
+            'payments.*.store_payment_method_id.required' => 'El método de pago es obligatorio.',
+            'payments.*.store_payment_method_id.exists' => 'El método de pago no es válido.',
+            'payments.*.amount.required' => 'El monto del pago es obligatorio.',
+            'payments.*.amount.numeric' => 'El monto debe ser un número.',
+            'payments.*.amount.min' => 'El monto debe ser mayor a 0.',
         ];
     }
 

--- a/app/Http/Resources/DeliveryRejectionReasonResource.php
+++ b/app/Http/Resources/DeliveryRejectionReasonResource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DeliveryRejectionReasonResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'code' => $this->code,
+            'label' => $this->label,
+            'store_id' => $this->store_id,
+            'is_active' => $this->is_active,
+        ];
+    }
+}

--- a/app/Http/Resources/DriverPaymentMethodResource.php
+++ b/app/Http/Resources/DriverPaymentMethodResource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DriverPaymentMethodResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'custom_name' => $this->custom_name,
+            'is_enabled' => $this->is_enabled,
+            'requires_reference' => $this->requires_reference,
+            'sort_order' => $this->sort_order,
+            'payment_method' => new PaymentMethodResource($this->whenLoaded('paymentMethod')),
+        ];
+    }
+}

--- a/app/Http/Resources/RouteStopResource.php
+++ b/app/Http/Resources/RouteStopResource.php
@@ -19,38 +19,55 @@ class RouteStopResource extends JsonResource
             'logistics_notes' => $this->logistics_notes,
             'estimated_arrival_at' => $this->estimated_arrival_at?->format('Y-m-d H:i:s'),
             'travel_duration_seconds' => $this->travel_duration_seconds,
-            'order' => $this->whenLoaded('order', fn () => [
-                'id' => $this->order->id,
-                'operation_number' => $this->order->operation_number,
-                'requested_delivery_date' => $this->order->requested_delivery_date?->format('Y-m-d'),
-                'customer' => $this->order->relationLoaded('customer') && $this->order->customer ? [
-                    'name' => $this->order->customer->display_name ?? $this->order->customer->name,
-                    'document' => $this->order->customer->document_number,
-                ] : null,
-                'address' => $this->when(
-                    $this->order->relationLoaded('customer') &&
-                    $this->order->customer &&
-                    $this->order->customer->relationLoaded('addresses'),
-                    function () {
-                        $mainAddress = $this->order->customer->addresses->firstWhere('is_main', true);
-                        return $mainAddress ? [
-                            'street' => $mainAddress->street,
-                            'number' => $mainAddress->number,
-                            'latitude' => (float) $mainAddress->latitude,
-                            'longitude' => (float) $mainAddress->longitude,
-                            'locality' => $mainAddress->relationLoaded('locality') && $mainAddress->locality
-                                ? $mainAddress->locality->name
-                                : null,
-                        ] : null;
-                    }
-                ),
-            ]),
+            'order' => $this->whenLoaded('order', function () {
+                $data = [
+                    'id' => $this->order->id,
+                    'operation_number' => $this->order->operation_number,
+                    'requested_delivery_date' => $this->order->requested_delivery_date?->format('Y-m-d'),
+                    'customer' => $this->order->relationLoaded('customer') && $this->order->customer ? [
+                        'name' => $this->order->customer->display_name ?? $this->order->customer->name,
+                        'document' => $this->order->customer->document_number,
+                    ] : null,
+                    'address' => $this->when(
+                        $this->order->relationLoaded('customer') &&
+                        $this->order->customer &&
+                        $this->order->customer->relationLoaded('addresses'),
+                        function () {
+                            $mainAddress = $this->order->customer->addresses->firstWhere('is_main', true);
+                            return $mainAddress ? [
+                                'street' => $mainAddress->street,
+                                'number' => $mainAddress->number,
+                                'latitude' => (float) $mainAddress->latitude,
+                                'longitude' => (float) $mainAddress->longitude,
+                                'locality' => $mainAddress->relationLoaded('locality') && $mainAddress->locality
+                                    ? $mainAddress->locality->name
+                                    : null,
+                            ] : null;
+                        }
+                    ),
+                ];
+
+                // Add financial data when items and payments are loaded
+                if ($this->order->relationLoaded('items') && $this->order->relationLoaded('payments')) {
+                    $totalAmount = (float) $this->order->items->sum(function ($item) {
+                        return (float) $item->quantity * (float) $item->price;
+                    });
+                    $paidAmount = (float) $this->order->payments->sum('amount');
+                    $data['total_amount'] = $totalAmount;
+                    $data['paid_amount'] = $paidAmount;
+                    $data['pending_balance'] = $totalAmount - $paidAmount;
+                }
+
+                return $data;
+            }),
             'created_at' => $this->created_at?->format('Y-m-d H:i:s'),
             'updated_at' => $this->updated_at?->format('Y-m-d H:i:s'),
             'items' => RouteStopItemResource::collection($this->whenLoaded('items')),
             'completed_at' => $this->completed_at?->format('Y-m-d H:i:s'),
             'gps_lat' => $this->gps_lat,
             'gps_lon' => $this->gps_lon,
+            'signature_uri' => $this->signature_uri,
+            'evidence_uris' => $this->evidence_uris,
         ];
     }
 }

--- a/app/Models/CommercialOperation.php
+++ b/app/Models/CommercialOperation.php
@@ -115,6 +115,30 @@ class CommercialOperation extends Model
         return $query;
     }
 
+    /**
+     * Sum of (quantity * price) across all operation items.
+     */
+    public function getTotalAmountAttribute(): float
+    {
+        return (float) $this->items()->sum(DB::raw('quantity * price'));
+    }
+
+    /**
+     * Sum of all recorded payments for this operation.
+     */
+    public function getPaidAmountAttribute(): float
+    {
+        return (float) $this->payments()->sum('amount');
+    }
+
+    /**
+     * total_amount minus paid_amount.
+     */
+    public function getPendingBalanceAttribute(): float
+    {
+        return $this->total_amount - $this->paid_amount;
+    }
+
     public function getDeliveryAddressAttribute(): ?CustomerAddress
     {
         if ($this->relationLoaded('customer')) {

--- a/app/Models/RouteStop.php
+++ b/app/Models/RouteStop.php
@@ -29,6 +29,8 @@ class RouteStop extends Model
         'completed_at',
         'gps_lat',
         'gps_lon',
+        'signature_uri',
+        'evidence_uris',
     ];
 
     protected function casts(): array
@@ -39,6 +41,7 @@ class RouteStop extends Model
             'completed_at' => 'datetime',
             'gps_lat' => 'decimal:7',
             'gps_lon' => 'decimal:7',
+            'evidence_uris' => 'array',
         ];
     }
 

--- a/app/Models/RouteStopCollection.php
+++ b/app/Models/RouteStopCollection.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RouteStopCollection extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'store_id',
+        'route_stop_id',
+        'commercial_operation_id',
+        'store_payment_method_id',
+        'amount',
+        'reference',
+        'notes',
+        'declared_by',
+        'declared_at',
+        'status',
+        'verified_by',
+        'verified_at',
+        'rejection_reason',
+        'operation_payment_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:2',
+            'declared_at' => 'datetime',
+            'verified_at' => 'datetime',
+        ];
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function routeStop(): BelongsTo
+    {
+        return $this->belongsTo(RouteStop::class);
+    }
+
+    public function commercialOperation(): BelongsTo
+    {
+        return $this->belongsTo(CommercialOperation::class);
+    }
+
+    public function storePaymentMethod(): BelongsTo
+    {
+        return $this->belongsTo(StorePaymentMethod::class);
+    }
+
+    public function declaredBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'declared_by');
+    }
+
+    public function verifiedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'verified_by');
+    }
+
+    public function scopeForStore(Builder $query, string $storeId): Builder
+    {
+        return $query->where('store_id', $storeId);
+    }
+}

--- a/app/OpenApi/Schemas/Driver/DriverPaymentMethodSchema.php
+++ b/app/OpenApi/Schemas/Driver/DriverPaymentMethodSchema.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\OpenApi\Schemas\Driver;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'DriverPaymentMethod',
+    title: 'DriverPaymentMethod',
+    description: 'Método de pago disponible para el conductor'
+)]
+class DriverPaymentMethodSchema
+{
+    #[OA\Property(format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')]
+    public string $id;
+
+    #[OA\Property(example: 'Transferencia Bco. Chile', nullable: true)]
+    public ?string $custom_name;
+
+    #[OA\Property(example: true)]
+    public bool $is_enabled;
+
+    #[OA\Property(example: true)]
+    public bool $requires_reference;
+
+    #[OA\Property(example: 1)]
+    public int $sort_order;
+
+    #[OA\Property(ref: '#/components/schemas/PaymentMethod', nullable: true)]
+    public ?object $payment_method;
+}

--- a/app/OpenApi/Schemas/Logistics/RejectionReasonSchema.php
+++ b/app/OpenApi/Schemas/Logistics/RejectionReasonSchema.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\OpenApi\Schemas\Logistics;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'RejectionReason',
+    title: 'RejectionReason',
+    description: 'Motivo de rechazo de una entrega'
+)]
+class RejectionReasonSchema
+{
+    #[OA\Property(format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')]
+    public string $id;
+
+    #[OA\Property(example: 'CUSTOMER_NOT_HOME')]
+    public string $code;
+
+    #[OA\Property(example: 'Cliente no se encontraba en el domicilio')]
+    public string $label;
+
+    #[OA\Property(example: true)]
+    public bool $is_active;
+}

--- a/app/Services/DriverExecutionService.php
+++ b/app/Services/DriverExecutionService.php
@@ -5,7 +5,9 @@ namespace App\Services;
 use App\Models\DeliveryRoute;
 use App\Models\DeliveryRouteEvent;
 use App\Models\RouteStop;
+use App\Models\RouteStopCollection;
 use App\Models\RouteStopItem;
+use App\Models\StorePaymentMethod;
 use App\Models\User;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Support\Facades\DB;
@@ -29,6 +31,9 @@ class DriverExecutionService
                 },
                 'stops.items.product',
                 'stops.order.customer',
+                'stops.order.items',
+                'stops.order.payments',
+                'stops.order.payments.storePaymentMethod.paymentMethod',
             ])
             ->first();
     }
@@ -41,6 +46,7 @@ class DriverExecutionService
         $route = $this->validateDriverRoute($stop, $driver);
 
         $stop->update([
+            'status' => 'arrived',
             'gps_lat' => $data['gps_lat'] ?? null,
             'gps_lon' => $data['gps_lon'] ?? null,
         ]);
@@ -60,7 +66,7 @@ class DriverExecutionService
             // Lock the stop to prevent race conditions
             $stop = RouteStop::where('id', $stop->id)->lockForUpdate()->first();
 
-            if ($stop->status !== 'pending') {
+            if (! in_array($stop->status, ['pending', 'arrived'])) {
                 throw $this->validationError('Este stop ya fue procesado.');
             }
 
@@ -114,12 +120,74 @@ class DriverExecutionService
             // Determine final status
             $finalStatus = $allZero ? 'failed' : 'completed';
 
+            // ── Process payments (collections) ──────────────────────────
+            $payments = $data['payments'] ?? [];
+
+            if (! empty($payments)) {
+                $order = $stop->order()
+                    ->with(['items', 'payments'])
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $order) {
+                    throw $this->validationError('No se encontró el pedido asociado a este stop.');
+                }
+
+                // Calculate pending balance
+                $totalAmount = (float) $order->items->sum(function ($item) {
+                    return (float) $item->quantity * (float) $item->price;
+                });
+
+                $paidAmount = (float) $order->payments->sum('amount');
+                $pendingBalance = $totalAmount - $paidAmount;
+
+                if ($pendingBalance <= 0) {
+                    throw $this->validationError('El pedido no tiene saldo pendiente.');
+                }
+
+                $declaredTotal = array_sum(array_map(fn ($p) => (float) $p['amount'], $payments));
+
+                if ($declaredTotal > $pendingBalance) {
+                    throw $this->validationError('El total declarado supera el saldo pendiente del pedido.');
+                }
+
+                // Validate each payment and create collection
+                foreach ($payments as $payment) {
+                    $storePaymentMethod = StorePaymentMethod::where('id', $payment['store_payment_method_id'])
+                        ->where('store_id', $route->store_id)
+                        ->first();
+
+                    if (! $storePaymentMethod) {
+                        throw $this->validationError('El método de pago no pertenece a la tienda.');
+                    }
+
+                    if ($storePaymentMethod->requires_reference && empty($payment['reference'])) {
+                        throw $this->validationError('El método de pago requiere una referencia.');
+                    }
+
+                    RouteStopCollection::create([
+                        'store_id' => $route->store_id,
+                        'route_stop_id' => $stop->id,
+                        'commercial_operation_id' => $order->id,
+                        'store_payment_method_id' => $payment['store_payment_method_id'],
+                        'amount' => $payment['amount'],
+                        'reference' => $payment['reference'] ?? null,
+                        'notes' => $payment['notes'] ?? null,
+                        'declared_by' => $driver->id,
+                        'declared_at' => now(),
+                        'status' => 'declared',
+                    ]);
+                }
+            }
+
             $stop->update([
                 'status' => $finalStatus,
                 'completed_by' => $driver->id,
                 'completed_at' => now(),
                 'gps_lat' => $data['gps_lat'] ?? null,
                 'gps_lon' => $data['gps_lon'] ?? null,
+                'signature_uri' => $data['signature_uri'] ?? null,
+                'evidence_uris' => $data['evidence_uris'] ?? null,
             ]);
 
             // Create event

--- a/database/migrations/2026_07_31_000001_add_evidence_columns_to_route_stops_table.php
+++ b/database/migrations/2026_07_31_000001_add_evidence_columns_to_route_stops_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('route_stops', function (Blueprint $table) {
+            $table->string('signature_uri', 500)->nullable()->after('gps_lon');
+            $table->json('evidence_uris')->nullable()->after('signature_uri');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('route_stops', function (Blueprint $table) {
+            $table->dropColumn(['evidence_uris', 'signature_uri']);
+        });
+    }
+};

--- a/database/migrations/2026_07_31_000002_create_route_stop_collections_table.php
+++ b/database/migrations/2026_07_31_000002_create_route_stop_collections_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('route_stop_collections', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('store_id');
+            $table->uuid('route_stop_id');
+            $table->uuid('commercial_operation_id');
+            $table->uuid('store_payment_method_id');
+            $table->decimal('amount', 12, 2);
+            $table->string('reference')->nullable();
+            $table->text('notes')->nullable();
+            $table->uuid('declared_by');
+            $table->timestamp('declared_at')->useCurrent();
+            $table->string('status')->default('declared');
+            $table->uuid('verified_by')->nullable();
+            $table->timestamp('verified_at')->nullable();
+            $table->string('rejection_reason')->nullable();
+            $table->uuid('operation_payment_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign('store_id')
+                ->references('id')
+                ->on('stores')
+                ->onDelete('restrict');
+
+            $table->foreign('route_stop_id')
+                ->references('id')
+                ->on('route_stops')
+                ->onDelete('cascade');
+
+            $table->foreign('commercial_operation_id')
+                ->references('id')
+                ->on('commercial_operations')
+                ->onDelete('restrict');
+
+            $table->foreign('store_payment_method_id')
+                ->references('id')
+                ->on('store_payment_methods')
+                ->onDelete('restrict');
+
+            $table->foreign('declared_by')
+                ->references('id')
+                ->on('users')
+                ->onDelete('restrict');
+
+            $table->index('store_id');
+            $table->index('route_stop_id');
+            $table->index('commercial_operation_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('route_stop_collections');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\Api\V1\Store\PaymentMethodController as StorePaymentMet
 use App\Http\Controllers\Api\V1\Store\PermissionCatalogController;
 use App\Http\Controllers\Api\V1\Store\ProductController;
 use App\Http\Controllers\Api\V1\Store\ProductSearchController;
+use App\Http\Controllers\Api\V1\Store\RejectionReasonController;
 use App\Http\Controllers\Api\V1\Store\RouteController;
 use App\Http\Controllers\Api\V1\Store\StoreUserController;
 use App\Http\Controllers\Api\V1\Store\StoreUserPermissionController;
@@ -212,6 +213,10 @@ Route::prefix('v1')->group(function () {
             });
 
             Route::middleware('feature:deliveries')->group(function () {
+                // Rejection reasons — global + store-specific
+                Route::get('logistics/rejection-reasons', [RejectionReasonController::class, 'index'])
+                    ->name('store.logistics.rejection-reasons');
+
                 // Catalog routes — MUST be before {vehicle} to avoid capture
                 Route::get('vehicles/catalogs/types', [VehicleCatalogController::class, 'types'])
                     ->middleware('permission:vehicles.view')

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -7510,7 +7510,18 @@
                                             "example": null
                                         },
                                         "data": {
-                                            "$ref": "#/components/schemas/DriverActiveRoute"
+                                            "properties": {
+                                                "route": {
+                                                    "$ref": "#/components/schemas/DeliveryRoute"
+                                                },
+                                                "available_payment_methods": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/DriverPaymentMethod"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
                                         },
                                         "errors": {
                                             "type": "null",
@@ -7702,6 +7713,20 @@
                                         "example": -58.3816,
                                         "nullable": true
                                     },
+                                    "signature_uri": {
+                                        "type": "string",
+                                        "maxLength": 500,
+                                        "example": "https://cdn.example.com/signatures/img001.png",
+                                        "nullable": true
+                                    },
+                                    "evidence_uris": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "example": "https://cdn.example.com/evidence/img001.png"
+                                        },
+                                        "nullable": true
+                                    },
                                     "rejection_reason_id": {
                                         "description": "Requerido si status=failed",
                                         "type": "string",
@@ -7733,6 +7758,30 @@
                                             },
                                             "type": "object"
                                         }
+                                    },
+                                    "payments": {
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "store_payment_method_id": {
+                                                    "type": "string",
+                                                    "format": "uuid",
+                                                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                                                },
+                                                "amount": {
+                                                    "type": "number",
+                                                    "format": "decimal",
+                                                    "example": 1500
+                                                },
+                                                "reference": {
+                                                    "type": "string",
+                                                    "example": "TRX-001234",
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "nullable": true
                                     }
                                 },
                                 "type": "object"
@@ -13130,6 +13179,57 @@
                 ]
             }
         },
+        "/store/logistics/rejection-reasons": {
+            "get": {
+                "tags": [
+                    "Store - Logística"
+                ],
+                "summary": "Listar motivos de rechazo",
+                "description": "List active rejection reasons — global plus store-specific.",
+                "operationId": "fdf211e232f5a901d5a42830fa427cf9",
+                "responses": {
+                    "200": {
+                        "description": "Listado de motivos de rechazo",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/RejectionReason"
+                                            }
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        },
+                                        "meta": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/store/routes/eligible-orders": {
             "get": {
                 "tags": [
@@ -16783,6 +16883,43 @@
                 },
                 "type": "object"
             },
+            "DriverPaymentMethod": {
+                "title": "DriverPaymentMethod",
+                "description": "Método de pago disponible para el conductor",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "custom_name": {
+                        "type": "string",
+                        "example": "Transferencia Bco. Chile",
+                        "nullable": true
+                    },
+                    "is_enabled": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "requires_reference": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "sort_order": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "payment_method": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PaymentMethod"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
             "GeocodingResult": {
                 "title": "GeocodingResult",
                 "description": "Resultado de la geocodificación de una dirección",
@@ -16873,6 +17010,30 @@
                         "type": "integer",
                         "example": 202,
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "RejectionReason": {
+                "title": "RejectionReason",
+                "description": "Motivo de rechazo de una entrega",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "code": {
+                        "type": "string",
+                        "example": "CUSTOMER_NOT_HOME"
+                    },
+                    "label": {
+                        "type": "string",
+                        "example": "Cliente no se encontraba en el domicilio"
+                    },
+                    "is_active": {
+                        "type": "boolean",
+                        "example": true
                     }
                 },
                 "type": "object"
@@ -18204,6 +18365,10 @@
         {
             "name": "Store - Usuarios",
             "description": "Store - Usuarios"
+        },
+        {
+            "name": "Store - Logística",
+            "description": "Store - Logística"
         },
         {
             "name": "Store - Rutas",

--- a/tests/Feature/Api/V1/Driver/DriverCollectionTest.php
+++ b/tests/Feature/Api/V1/Driver/DriverCollectionTest.php
@@ -1,0 +1,537 @@
+<?php
+
+use App\Models\CommercialOperation;
+use App\Models\DeliveryRejectionReason;
+use App\Models\DeliveryRoute;
+use App\Models\Feature;
+use App\Models\OperationItem;
+use App\Models\OperationPayment;
+use App\Models\PaymentMethod;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\RouteStop;
+use App\Models\RouteStopItem;
+use App\Models\Store;
+use App\Models\StorePaymentMethod;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Role::create(['name' => 'STORE_ADMIN', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_DRIVER', 'guard_name' => 'web']);
+    Role::create(['name' => 'STORE_USER', 'guard_name' => 'web']);
+
+    $this->store = Store::factory()->create();
+
+    $plan = Plan::factory()->create();
+    $dFeature = Feature::create(['code' => 'deliveries', 'name' => 'Entregas']);
+    $plan->features()->attach($dFeature->id);
+    $this->store->update(['plan_id' => $plan->id]);
+
+    $this->vehicle = Vehicle::factory()->create(['store_id' => $this->store->id]);
+
+    $this->driver = User::factory()->create(['store_id' => $this->store->id]);
+    $this->driver->assignRole('STORE_DRIVER');
+    $this->driverToken = $this->driver->createToken('driver-test')->plainTextToken;
+
+    $this->nonDriver = User::factory()->create(['store_id' => $this->store->id]);
+    $this->nonDriver->assignRole('STORE_ADMIN');
+    $this->nonDriverToken = $this->nonDriver->createToken('admin-test')->plainTextToken;
+
+    $this->storeUser = User::factory()->create(['store_id' => $this->store->id]);
+    $this->storeUser->assignRole('STORE_USER');
+    $this->storeUserToken = $this->storeUser->createToken('user-test')->plainTextToken;
+
+    $this->seed(\Database\Seeders\DeliveryRejectionReasonSeeder::class);
+});
+
+// ─── Helper: create a dispatched route with stops, items, and order financials ──
+
+function createDispatchedRouteWithFinancials(User $driver, Store $store, Vehicle $vehicle): array
+{
+    $product1 = Product::factory()->create(['store_id' => $store->id]);
+    $product2 = Product::factory()->create(['store_id' => $store->id]);
+
+    // Create CommercialOperation with items
+    $order = CommercialOperation::factory()->create([
+        'store_id' => $store->id,
+        'type' => 'order',
+        'status' => 'confirmed',
+        'total' => 1500.00,
+        'subtotal' => 1260.50,
+        'tax' => 239.50,
+    ]);
+
+    $item1 = OperationItem::factory()->create([
+        'operation_id' => $order->id,
+        'product_id' => $product1->id,
+        'quantity' => 10,
+        'price' => 100.00,
+        'subtotal' => 1000.00,
+    ]);
+
+    $item2 = OperationItem::factory()->create([
+        'operation_id' => $order->id,
+        'product_id' => $product2->id,
+        'quantity' => 5,
+        'price' => 100.00,
+        'subtotal' => 500.00,
+    ]);
+
+    // Create payments: 800 paid, 700 pending
+    $pm1 = PaymentMethod::factory()->create();
+    $spm1 = StorePaymentMethod::factory()->create([
+        'store_id' => $store->id,
+        'payment_method_id' => $pm1->id,
+        'requires_reference' => false,
+    ]);
+
+    $pay1 = OperationPayment::factory()->create([
+        'operation_id' => $order->id,
+        'store_payment_method_id' => $spm1->id,
+        'amount' => 800.00,
+    ]);
+
+    $route = DeliveryRoute::factory()->create([
+        'store_id' => $store->id,
+        'vehicle_id' => $vehicle->id,
+        'driver_id' => $driver->id,
+        'status' => 'dispatched',
+        'dispatched_at' => now(),
+    ]);
+
+    $stop1 = RouteStop::factory()->create([
+        'route_id' => $route->id,
+        'order_id' => $order->id,
+        'sequence' => 1,
+        'status' => 'pending',
+    ]);
+
+    $stop2 = RouteStop::factory()->create([
+        'route_id' => $route->id,
+        'sequence' => 2,
+        'status' => 'pending',
+    ]);
+
+    $stopItem1 = RouteStopItem::factory()->create([
+        'route_stop_id' => $stop1->id,
+        'product_id' => $product1->id,
+        'quantity_planned' => 10,
+        'quantity_loaded' => 10,
+        'quantity_delivered' => 0,
+    ]);
+
+    $stopItem2 = RouteStopItem::factory()->create([
+        'route_stop_id' => $stop1->id,
+        'product_id' => $product2->id,
+        'quantity_planned' => 5,
+        'quantity_loaded' => 5,
+        'quantity_delivered' => 0,
+    ]);
+
+    return [
+        'route' => $route,
+        'order' => $order,
+        'stops' => [$stop1, $stop2],
+        'stopItems' => [$stopItem1, $stopItem2],
+        'product1' => $product1,
+        'product2' => $product2,
+        'spm1' => $spm1,
+        'pay1' => $pay1,
+    ];
+}
+
+// ─── Helper: simple dispatched route (original) ──
+
+function createDispatchedRouteSimple(User $driver, Store $store, Vehicle $vehicle): array
+{
+    $route = DeliveryRoute::factory()->create([
+        'store_id' => $store->id,
+        'vehicle_id' => $vehicle->id,
+        'driver_id' => $driver->id,
+        'status' => 'dispatched',
+        'dispatched_at' => now(),
+    ]);
+
+    $product1 = Product::factory()->create(['store_id' => $store->id]);
+
+    $stop1 = RouteStop::factory()->create([
+        'route_id' => $route->id,
+        'sequence' => 1,
+        'status' => 'pending',
+    ]);
+
+    $stopItem1 = RouteStopItem::factory()->create([
+        'route_stop_id' => $stop1->id,
+        'product_id' => $product1->id,
+        'quantity_planned' => 10,
+        'quantity_loaded' => 10,
+        'quantity_delivered' => 0,
+    ]);
+
+    return [
+        'route' => $route,
+        'stops' => [$stop1],
+        'items' => [$stopItem1],
+    ];
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 5: Rejection Reasons endpoint
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('rejection reasons returns active global reasons for store user', function () {
+    $response = $this->withHeader('Authorization', "Bearer {$this->storeUserToken}")
+        ->getJson('/api/v1/store/logistics/rejection-reasons');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('status', 'success')
+        ->assertJsonCount(DeliveryRejectionReason::whereNull('store_id')->where('is_active', true)->count(), 'data');
+});
+
+test('rejection reasons returns global plus store-specific reasons', function () {
+    $globalCount = DeliveryRejectionReason::whereNull('store_id')->where('is_active', true)->count();
+
+    DeliveryRejectionReason::create([
+        'store_id' => $this->store->id,
+        'code' => 'tienda_cerrada',
+        'label' => 'Tienda cerrada por feriado',
+        'is_active' => true,
+    ]);
+
+    DeliveryRejectionReason::create([
+        'store_id' => $this->store->id,
+        'code' => 'zona_peligrosa',
+        'label' => 'Zona peligrosa',
+        'is_active' => false, // inactive — should NOT appear
+    ]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->storeUserToken}")
+        ->getJson('/api/v1/store/logistics/rejection-reasons');
+
+    $response->assertStatus(200)
+        ->assertJsonCount($globalCount + 1, 'data'); // global + 1 active store-specific
+});
+
+test('rejection reasons returns 401 for unauthenticated', function () {
+    $response = $this->getJson('/api/v1/store/logistics/rejection-reasons');
+    $response->assertStatus(401);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 6: active-route returns financial data and payment methods
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('active route includes available_payment_methods', function () {
+    $data = createDispatchedRouteSimple($this->driver, $this->store, $this->vehicle);
+
+    $pm = PaymentMethod::factory()->create();
+    $spm = StorePaymentMethod::factory()->create([
+        'store_id' => $this->store->id,
+        'payment_method_id' => $pm->id,
+        'is_enabled' => true,
+    ]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.available_payment_methods.0.id', $spm->id)
+        ->assertJsonPath('data.available_payment_methods.0.payment_method.id', $pm->id);
+});
+
+test('active route includes order financial data in stops', function () {
+    $data = createDispatchedRouteWithFinancials($this->driver, $this->store, $this->vehicle);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->getJson('/api/v1/driver/active-route');
+
+    $response->assertStatus(200);
+
+    // Check stop 1 has financial data in order (use float-compatible assertions)
+    $stopData = $response->json('data.route.stops.0.order');
+    expect((float) $stopData['total_amount'])->toEqualWithDelta(1500.00, 0.01);
+    expect((float) $stopData['paid_amount'])->toEqualWithDelta(800.00, 0.01);
+    expect((float) $stopData['pending_balance'])->toEqualWithDelta(700.00, 0.01);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 3a: arriveStop sets status to 'arrived'
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('arrive sets stop status to arrived', function () {
+    $data = createDispatchedRouteSimple($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/arrive", [
+            'gps_lat' => -34.6037,
+            'gps_lon' => -58.3816,
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'arrived');
+
+    $this->assertDatabaseHas('route_stops', [
+        'id' => $stop->id,
+        'status' => 'arrived',
+        'gps_lat' => -34.6037000,
+        'gps_lon' => -58.3816000,
+    ]);
+});
+
+test('arrive works without gps coordinates', function () {
+    $data = createDispatchedRouteSimple($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/arrive", []);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'arrived');
+
+    $this->assertDatabaseHas('route_stops', [
+        'id' => $stop->id,
+        'status' => 'arrived',
+    ]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 3c: completeStop with payment collections
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('complete stop with payments creates route_stop_collections', function () {
+    $data = createDispatchedRouteWithFinancials($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItems = $data['stopItems'];
+
+    $pm2 = PaymentMethod::factory()->create();
+    $spm2 = StorePaymentMethod::factory()->create([
+        'store_id' => $this->store->id,
+        'payment_method_id' => $pm2->id,
+        'requires_reference' => false,
+    ]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItems[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $stopItems[1]->id, 'quantity_delivered' => 5],
+            ],
+            'payments' => [
+                ['store_payment_method_id' => $data['spm1']->id, 'amount' => 400.00, 'reference' => '12345'],
+                ['store_payment_method_id' => $spm2->id, 'amount' => 300.00],
+            ],
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'completed');
+
+    // Verify collections were created
+    $this->assertDatabaseHas('route_stop_collections', [
+        'route_stop_id' => $stop->id,
+        'store_payment_method_id' => $data['spm1']->id,
+        'amount' => 400.00,
+        'reference' => '12345',
+        'status' => 'declared',
+        'declared_by' => $this->driver->id,
+    ]);
+
+    $this->assertDatabaseHas('route_stop_collections', [
+        'route_stop_id' => $stop->id,
+        'store_payment_method_id' => $spm2->id,
+        'amount' => 300.00,
+        'status' => 'declared',
+        'declared_by' => $this->driver->id,
+    ]);
+
+    // Should have exactly 2 collections
+    $this->assertEquals(2, \App\Models\RouteStopCollection::where('route_stop_id', $stop->id)->count());
+});
+
+test('complete stop rejects payments when pending balance is zero', function () {
+    $data = createDispatchedRouteWithFinancials($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItems = $data['stopItems'];
+
+    // Pay remaining balance to make it zero
+    OperationPayment::factory()->create([
+        'operation_id' => $data['order']->id,
+        'store_payment_method_id' => $data['spm1']->id,
+        'amount' => 700.00,
+    ]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItems[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $stopItems[1]->id, 'quantity_delivered' => 5],
+            ],
+            'payments' => [
+                ['store_payment_method_id' => $data['spm1']->id, 'amount' => 100.00],
+            ],
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'El pedido no tiene saldo pendiente.');
+});
+
+test('complete stop rejects payments when total exceeds pending balance', function () {
+    $data = createDispatchedRouteWithFinancials($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItems = $data['stopItems'];
+
+    // Pending balance is 700 (1500 total - 800 paid)
+    // Try to collect 800 (exceeds 700)
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItems[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $stopItems[1]->id, 'quantity_delivered' => 5],
+            ],
+            'payments' => [
+                ['store_payment_method_id' => $data['spm1']->id, 'amount' => 800.00],
+            ],
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'El total declarado supera el saldo pendiente del pedido.');
+});
+
+test('complete stop validates payment method belongs to store', function () {
+    $data = createDispatchedRouteWithFinancials($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItems = $data['stopItems'];
+
+    // Create a payment method belonging to ANOTHER store
+    $otherStore = Store::factory()->create();
+    $pmOther = PaymentMethod::factory()->create();
+    $spmOther = StorePaymentMethod::factory()->create([
+        'store_id' => $otherStore->id,
+        'payment_method_id' => $pmOther->id,
+        'requires_reference' => false,
+    ]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItems[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $stopItems[1]->id, 'quantity_delivered' => 5],
+            ],
+            'payments' => [
+                ['store_payment_method_id' => $spmOther->id, 'amount' => 100.00],
+            ],
+        ]);
+
+    $response->assertStatus(422);
+});
+
+test('complete stop validates reference required when method requires it', function () {
+    $data = createDispatchedRouteWithFinancials($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItems = $data['stopItems'];
+
+    // Make the payment method require reference
+    $data['spm1']->update(['requires_reference' => true]);
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItems[0]->id, 'quantity_delivered' => 10],
+                ['route_stop_item_id' => $stopItems[1]->id, 'quantity_delivered' => 5],
+            ],
+            'payments' => [
+                ['store_payment_method_id' => $data['spm1']->id, 'amount' => 100.00],
+            ],
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'El método de pago requiere una referencia.');
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 3c: completeStop with evidence
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('complete stop with evidence saves signature_uri and evidence_uris', function () {
+    $data = createDispatchedRouteSimple($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItem = $data['items'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItem->id, 'quantity_delivered' => 10],
+            ],
+            'signature_uri' => 'https://storage.example.com/signatures/sig123.png',
+            'evidence_uris' => [
+                'https://storage.example.com/photos/photo1.jpg',
+                'https://storage.example.com/photos/photo2.jpg',
+            ],
+        ]);
+
+    $response->assertStatus(200);
+
+    $this->assertDatabaseHas('route_stops', [
+        'id' => $stop->id,
+        'signature_uri' => 'https://storage.example.com/signatures/sig123.png',
+    ]);
+
+    $stopFresh = RouteStop::find($stop->id);
+    $this->assertIsArray($stopFresh->evidence_uris);
+    $this->assertCount(2, $stopFresh->evidence_uris);
+    $this->assertEquals('https://storage.example.com/photos/photo1.jpg', $stopFresh->evidence_uris[0]);
+});
+
+test('complete stop without payments works as before (backward compatibility)', function () {
+    $data = createDispatchedRouteSimple($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItem = $data['items'][0];
+
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItem->id, 'quantity_delivered' => 10],
+            ],
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'completed');
+});
+
+test('complete stop can process from arrived status', function () {
+    $data = createDispatchedRouteSimple($this->driver, $this->store, $this->vehicle);
+    $stop = $data['stops'][0];
+    $stopItem = $data['items'][0];
+
+    // First arrive
+    $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/arrive", [])
+        ->assertStatus(200);
+
+    // Then complete
+    $response = $this->withHeader('Authorization', "Bearer {$this->driverToken}")
+        ->postJson("/api/v1/driver/stops/{$stop->id}/complete", [
+            'status' => 'completed',
+            'items' => [
+                ['route_stop_item_id' => $stopItem->id, 'quantity_delivered' => 10],
+            ],
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.status', 'completed');
+});

--- a/tests/Feature/Api/V1/Driver/DriverExecutionTest.php
+++ b/tests/Feature/Api/V1/Driver/DriverExecutionTest.php
@@ -115,10 +115,10 @@ test('active route returns dispatched route for assigned driver', function () {
         ->getJson('/api/v1/driver/active-route');
 
     $response->assertStatus(200)
-        ->assertJsonPath('data.id', $data['route']->id)
-        ->assertJsonPath('data.status', 'dispatched')
-        ->assertJsonPath('data.stops.0.id', $data['stops'][0]->id)
-        ->assertJsonPath('data.stops.1.id', $data['stops'][1]->id);
+        ->assertJsonPath('data.route.id', $data['route']->id)
+        ->assertJsonPath('data.route.status', 'dispatched')
+        ->assertJsonPath('data.route.stops.0.id', $data['stops'][0]->id)
+        ->assertJsonPath('data.route.stops.1.id', $data['stops'][1]->id);
 });
 
 test('active route returns 404 when driver has no dispatched route', function () {
@@ -156,8 +156,8 @@ test('active route loads vehicle, stops, items, and customer relations', functio
         ->getJson('/api/v1/driver/active-route');
 
     $response->assertStatus(200)
-        ->assertJsonPath('data.vehicle.id', $this->vehicle->id)
-        ->assertJsonPath('data.stops.0.items.0.id', $data['items'][0]->id);
+        ->assertJsonPath('data.route.vehicle.id', $this->vehicle->id)
+        ->assertJsonPath('data.route.stops.0.items.0.id', $data['items'][0]->id);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
feat: add signature_uri and evidence_uris fields to RouteStop model

feat: create RouteStopCollection model for payment collections related to route stops

feat: add DriverPaymentMethod schema for OpenAPI documentation

feat: add RejectionReason schema for OpenAPI documentation

feat: implement payment collection logic in DriverExecutionService

feat: add migration for new evidence columns in route_stops table

feat: create migration for route_stop_collections table

feat: add rejection reasons endpoint to API routes

docs: update API documentation for new endpoints and schemas

test: add comprehensive tests for driver payment collections and rejection reasons