### PR TITLE
feat(route-management): add adjust-items endpoint for redistributing loaded quantities across stops

### DIFF
--- a/app/Http/Controllers/Api/V1/Store/RouteController.php
+++ b/app/Http/Controllers/Api/V1/Store/RouteController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1\Store;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Store\AddStopRequest;
+use App\Http\Requests\Api\V1\Store\AdjustItemsRequest;
 use App\Http\Requests\Api\V1\Store\CancelRouteRequest;
 use App\Http\Requests\Api\V1\Store\BulkLoadRequest;
 use App\Http\Requests\Api\V1\Store\ConfirmLoadRequest;
@@ -1183,6 +1184,85 @@ class RouteController extends Controller
         return response()->json([
             'status' => 'success',
             'message' => 'Carga consolidada confirmada exitosamente.',
+            'data' => DeliveryRouteResource::make($route),
+            'errors' => null,
+        ]);
+    }
+
+    /**
+     * Redistribute loaded quantities for a specific product across stops.
+     *
+     * @OA\Post(
+     *   path="/store/routes/{route}/adjust-items",
+     *   summary="Redistribuir cantidades cargadas de un producto entre paradas",
+     *   tags={"Store - Rutas"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="route", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID de la ruta"),
+     *
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(
+     *       required={"product_id", "items"},
+     *       @OA\Property(property="product_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
+     *       @OA\Property(
+     *         property="items",
+     *         type="array",
+     *         @OA\Items(
+     *           required={"route_stop_item_id", "quantity_loaded"},
+     *           @OA\Property(property="route_stop_item_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440001"),
+     *           @OA\Property(property="quantity_loaded", type="integer", example=5),
+     *           @OA\Property(property="reason", type="string", nullable=true, example="Redistribución manual"),
+     *           @OA\Property(property="notes", type="string", nullable=true)
+     *         )
+     *       )
+     *     )
+     *   ),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Items ajustados exitosamente",
+     *
+     *     @OA\JsonContent(
+     *
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="string", example="Items ajustados exitosamente."),
+     *       @OA\Property(property="data", ref="#/components/schemas/DeliveryRoute"),
+     *       @OA\Property(property="errors", type="null", example=null)
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=422, description="Error de validación"),
+     *   @OA\Response(response=404, description="Ruta no encontrada")
+     * )
+     */
+    public function adjustItems(AdjustItemsRequest $request, string $routeId): JsonResponse
+    {
+        $storeId = $request->user()->store_id;
+
+        $route = DeliveryRoute::forStore($storeId)->find($routeId);
+
+        if (! $route) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Ruta no encontrada.',
+                'data' => null,
+                'errors' => ['id' => ['La ruta no existe o no pertenece a tu tienda.']],
+            ], 404);
+        }
+
+        $route = $this->routeService->adjustItems(
+            $route,
+            $request->input('product_id'),
+            $request->input('items'),
+            $request->user()
+        );
+
+        $route->load(['stops' => fn ($q) => $q->orderBy('sequence'), 'stops.items.product', 'vehicle', 'driver', 'events']);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Items ajustados exitosamente.',
             'data' => DeliveryRouteResource::make($route),
             'errors' => null,
         ]);

--- a/app/Http/Requests/Api/V1/Store/AdjustItemsRequest.php
+++ b/app/Http/Requests/Api/V1/Store/AdjustItemsRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Store;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class AdjustItemsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id' => ['required', 'uuid', 'exists:products,id'],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.route_stop_item_id' => ['required', 'uuid', 'exists:route_stop_items,id'],
+            'items.*.quantity_loaded' => ['required', 'integer', 'min:0'],
+            'items.*.reason' => ['nullable', 'string'],
+            'items.*.notes' => ['nullable', 'string'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'product_id.required' => 'El ID del producto es obligatorio.',
+            'product_id.exists' => 'El producto seleccionado no existe.',
+            'items.required' => 'Los items son obligatorios.',
+            'items.array' => 'Los items deben ser un array.',
+            'items.min' => 'Debe haber al menos un item.',
+            'items.*.route_stop_item_id.required' => 'El ID del item de parada es obligatorio.',
+            'items.*.route_stop_item_id.exists' => 'Uno o más items no existen.',
+            'items.*.quantity_loaded.required' => 'La cantidad cargada es obligatoria.',
+            'items.*.quantity_loaded.integer' => 'La cantidad cargada debe ser un número entero.',
+            'items.*.quantity_loaded.min' => 'La cantidad cargada no puede ser negativa.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Services/RouteManagementService.php
+++ b/app/Services/RouteManagementService.php
@@ -1657,6 +1657,118 @@ class RouteManagementService
     }
 
     /**
+     * Redistribute loaded quantities for a specific product across stops.
+     * The total sum of quantity_loaded for this product in this route
+     * must remain unchanged — this is a redistribution, not creation/deletion.
+     * Only works on routes in 'loaded' state.
+     */
+    public function adjustItems(DeliveryRoute $route, string $productId, array $items, User $user): DeliveryRoute
+    {
+        return DB::transaction(function () use ($route, $productId, $items, $user) {
+            if ($route->status !== 'loaded') {
+                throw $this->validationError('Solo se pueden ajustar items en rutas cargadas.');
+            }
+
+            $route = DeliveryRoute::where('id', $route->id)->lockForUpdate()->first();
+
+            // Calculate current total for this product in this route
+            $currentTotal = RouteStopItem::where('product_id', $productId)
+                ->whereHas('routeStop', function (Builder $q) use ($route) {
+                    $q->where('route_id', $route->id)
+                        ->where('status', '!=', 'cancelled');
+                })
+                ->sum('quantity_loaded');
+
+            $newTotal = 0;
+            $validatedItems = [];
+
+            foreach ($items as $entry) {
+                $routeStopItemId = $entry['route_stop_item_id'];
+                $quantityLoaded = (int) $entry['quantity_loaded'];
+                $newTotal += $quantityLoaded;
+
+                $stopItem = RouteStopItem::where('id', $routeStopItemId)
+                    ->where('product_id', $productId)
+                    ->whereHas('routeStop', function (Builder $q) use ($route) {
+                        $q->where('route_id', $route->id)
+                            ->where('status', '!=', 'cancelled');
+                    })
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $stopItem) {
+                    throw $this->validationError(
+                        "El item {$routeStopItemId} no pertenece a esta ruta o no corresponde al producto indicado."
+                    );
+                }
+
+                if ($quantityLoaded > $stopItem->quantity_planned) {
+                    throw $this->validationError(
+                        "La cantidad cargada ({$quantityLoaded}) no puede superar la planificada ({$stopItem->quantity_planned}) ".
+                        "para el item {$routeStopItemId}."
+                    );
+                }
+
+                $validatedItems[] = [
+                    'item' => $stopItem,
+                    'quantity_loaded' => $quantityLoaded,
+                    'reason' => $entry['reason'] ?? null,
+                    'notes' => $entry['notes'] ?? null,
+                ];
+            }
+
+            // Conservation rule: total must not change
+            if ($newTotal !== (int) $currentTotal) {
+                throw $this->validationError(
+                    "La suma de las cantidades cargadas ({$newTotal}) debe ser igual ".
+                    "al total actual cargado ({$currentTotal}) para este producto. ".
+                    "Solo se permite redistribuir, no crear ni eliminar mercadería."
+                );
+            }
+
+            // Apply updates
+            foreach ($validatedItems as $entry) {
+                /** @var RouteStopItem $stopItem */
+                $stopItem = $entry['item'];
+                $oldQuantity = $stopItem->quantity_loaded;
+                $newQuantity = $entry['quantity_loaded'];
+
+                if ($oldQuantity !== $newQuantity) {
+                    // Create adjustment record
+                    RouteLoadAdjustment::create([
+                        'route_stop_item_id' => $stopItem->id,
+                        'user_id' => $user->id,
+                        'old_quantity' => $oldQuantity,
+                        'new_quantity' => $newQuantity,
+                        'reason' => $entry['reason'] ?? 'redistribution',
+                        'notes' => $entry['notes'] ?? null,
+                    ]);
+                }
+
+                $stopItem->update(['quantity_loaded' => $newQuantity]);
+            }
+
+            $this->createEvent(
+                $route,
+                $route->store_id,
+                $user->id,
+                'items_adjusted',
+                null,
+                null,
+                null,
+                [
+                    'product_id' => $productId,
+                    'previous_total' => (int) $currentTotal,
+                    'new_total' => $newTotal,
+                    'item_count' => count($validatedItems),
+                ]
+            );
+
+            return $route;
+        });
+    }
+
+    /**
      * For a given product in the route, create RouteLoadAdjustment records
      * for every stop item where quantity_loaded is less than quantity_planned.
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -325,6 +325,10 @@ Route::prefix('v1')->group(function () {
                     ->middleware('permission:logistics.routes.load')
                     ->name('store.routes.confirm-load');
 
+                Route::post('routes/{route}/adjust-items', [RouteController::class, 'adjustItems'])
+                    ->middleware('permission:logistics.routes.load')
+                    ->name('store.routes.adjust-items');
+
                 Route::post('routes/{route}/bulk-load', [RouteController::class, 'bulkLoad'])
                     ->middleware('permission:logistics.routes.load')
                     ->name('store.routes.bulk-load');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -14858,6 +14858,227 @@
                 ]
             }
         },
+        "/store/routes/{route}/bulk-load": {
+            "post": {
+                "tags": [
+                    "Store - Rutas"
+                ],
+                "summary": "Carga consolidada con distribución automática por producto",
+                "description": "Consolidated load: receive product-level quantities and distribute across stops.",
+                "operationId": "7c9c89eb3428b6e85516dcc0f7910f12",
+                "parameters": [
+                    {
+                        "name": "route",
+                        "in": "path",
+                        "description": "ID de la ruta",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "products"
+                                ],
+                                "properties": {
+                                    "products": {
+                                        "type": "array",
+                                        "items": {
+                                            "required": [
+                                                "product_id",
+                                                "quantity_loaded"
+                                            ],
+                                            "properties": {
+                                                "product_id": {
+                                                    "type": "string",
+                                                    "format": "uuid",
+                                                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                                                },
+                                                "quantity_loaded": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                },
+                                                "reason": {
+                                                    "type": "string",
+                                                    "example": "Falta de stock en depósito",
+                                                    "nullable": true
+                                                },
+                                                "notes": {
+                                                    "type": "string",
+                                                    "example": "Solo 10 de 15 disponibles",
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Carga consolidada confirmada exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Carga consolidada confirmada exitosamente."
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/DeliveryRoute"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Error de validación"
+                    },
+                    "404": {
+                        "description": "Ruta no encontrada"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/store/routes/{route}/adjust-items": {
+            "post": {
+                "tags": [
+                    "Store - Rutas"
+                ],
+                "summary": "Redistribuir cantidades cargadas de un producto entre paradas",
+                "description": "Redistribute loaded quantities for a specific product across stops.",
+                "operationId": "773fc859244c8a56ec8e7df35c96fea7",
+                "parameters": [
+                    {
+                        "name": "route",
+                        "in": "path",
+                        "description": "ID de la ruta",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "product_id",
+                                    "items"
+                                ],
+                                "properties": {
+                                    "product_id": {
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                                    },
+                                    "items": {
+                                        "type": "array",
+                                        "items": {
+                                            "required": [
+                                                "route_stop_item_id",
+                                                "quantity_loaded"
+                                            ],
+                                            "properties": {
+                                                "route_stop_item_id": {
+                                                    "type": "string",
+                                                    "format": "uuid",
+                                                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                                                },
+                                                "quantity_loaded": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                },
+                                                "reason": {
+                                                    "type": "string",
+                                                    "example": "Redistribución manual",
+                                                    "nullable": true
+                                                },
+                                                "notes": {
+                                                    "type": "string",
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Items ajustados exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Items ajustados exitosamente."
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/DeliveryRoute"
+                                        },
+                                        "errors": {
+                                            "type": "null",
+                                            "example": null
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Error de validación"
+                    },
+                    "404": {
+                        "description": "Ruta no encontrada"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/store/routes/{route}/dispatch": {
             "post": {
                 "tags": [


### PR DESCRIPTION
Add adjust-items endpoint for redistributing loaded quantities across stops