### PR TITLE
feat(api): implement extra sales functionality for drivers with available surplus and allocation management

### DIFF
--- a/app/Http/Controllers/Api/V1/Driver/DriverExtraSaleController.php
+++ b/app/Http/Controllers/Api/V1/Driver/DriverExtraSaleController.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Driver\AddExtraSaleRequest;
+use App\Models\RouteStop;
+use App\Services\DriverExecutionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DriverExtraSaleController extends Controller
+{
+    public function __construct(
+        private DriverExecutionService $executionService
+    ) {}
+
+    /**
+     * Get available surplus products on the route from completed/failed stops.
+     *
+     * @OA\Get(
+     *   path="/driver/routes/{route}/available-surplus",
+     *   summary="Obtener excedentes disponibles en la ruta",
+     *   tags={"Driver"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="route", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID de la ruta"),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Excedentes disponibles obtenidos correctamente",
+     *
+     *     @OA\JsonContent(
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="string", example="Excedentes disponibles obtenidos correctamente."),
+     *       @OA\Property(
+     *         property="data",
+     *         type="object",
+     *         @OA\Property(property="route_id", type="string", format="uuid"),
+     *         @OA\Property(
+     *           property="surplus",
+     *           type="array",
+     *           @OA\Items(ref="#/components/schemas/AvailableSurplus")
+     *         )
+     *       )
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=404, description="Ruta no encontrada o no está en estado despachado")
+     * )
+     */
+    public function availableSurplus(Request $request, string $routeId): JsonResponse
+    {
+        $driver = $request->user();
+
+        $surplus = $this->executionService->getAvailableSurplus($routeId, $driver->store_id);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Excedentes disponibles obtenidos correctamente.',
+            'data' => [
+                'route_id' => $routeId,
+                'surplus' => $surplus,
+            ],
+        ]);
+    }
+
+    /**
+     * Add extra sale items to a pending/arrived stop.
+     *
+     * @OA\Post(
+     *   path="/driver/stops/{stop}/extra-sales",
+     *   summary="Agregar venta extra a una parada",
+     *   tags={"Driver"},
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="stop", in="path", required=true, @OA\Schema(type="string", format="uuid"), description="ID del RouteStop"),
+     *
+     *   @OA\RequestBody(
+     *     required=true,
+     *
+     *     @OA\JsonContent(
+     *       required={"items"},
+     *       @OA\Property(
+     *         property="items",
+     *         type="array",
+     *         @OA\Items(
+     *           required={"product_id", "quantity"},
+     *           @OA\Property(property="product_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
+     *           @OA\Property(property="quantity", type="integer", minimum=1, example=3)
+     *         )
+     *       )
+     *     )
+     *   ),
+     *
+     *   @OA\Response(
+     *     response=200,
+     *     description="Venta extra agregada correctamente",
+     *
+     *     @OA\JsonContent(
+     *       @OA\Property(property="status", type="string", example="success"),
+     *       @OA\Property(property="message", type="string", example="Venta extra agregada correctamente."),
+     *       @OA\Property(
+     *         property="data",
+     *         type="object",
+     *         @OA\Property(
+     *           property="stop",
+     *           type="object",
+     *           @OA\Property(property="id", type="string", format="uuid"),
+     *           @OA\Property(property="route_id", type="string", format="uuid"),
+     *           @OA\Property(property="sequence", type="integer"),
+     *           @OA\Property(property="status", type="string"),
+     *           @OA\Property(
+     *             property="order",
+     *             type="object",
+     *             nullable=true,
+     *             @OA\Property(property="id", type="string", format="uuid"),
+     *             @OA\Property(property="operation_number", type="string"),
+     *             @OA\Property(property="total", type="number"),
+     *             @OA\Property(property="pending_balance", type="number")
+     *           ),
+     *           @OA\Property(
+     *             property="items",
+     *             type="array",
+     *             @OA\Items(ref="#/components/schemas/ExtraSaleItem")
+     *           )
+     *         )
+     *       )
+     *     )
+     *   ),
+     *
+     *   @OA\Response(response=404, description="Parada o ruta no encontrada"),
+     *   @OA\Response(response=422, description="Error de validación - cantidad excede disponible o stop no está en estado válido")
+     * )
+     */
+    public function addExtraSale(AddExtraSaleRequest $request, string $stopId): JsonResponse
+    {
+        $driver = $request->user();
+        $items = $request->validated()['items'];
+
+        $stop = $this->executionService->addExtraSale($stopId, $items, $driver);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Venta extra agregada correctamente.',
+            'data' => [
+                'stop' => [
+                    'id' => $stop->id,
+                    'route_id' => $stop->route_id,
+                    'sequence' => $stop->sequence,
+                    'status' => $stop->status,
+                    'order' => $stop->order ? [
+                        'id' => $stop->order->id,
+                        'operation_number' => $stop->order->operation_number,
+                        'total' => (float) $stop->order->total,
+                        'pending_balance' => $stop->order->pending_balance,
+                    ] : null,
+                    'items' => $stop->items->map(fn ($item) => [
+                        'id' => $item->id,
+                        'product_id' => $item->product_id,
+                        'product_name' => $item->product?->name,
+                        'quantity_planned' => $item->quantity_planned,
+                        'quantity_loaded' => $item->quantity_loaded,
+                        'quantity_delivered' => $item->quantity_delivered,
+                        'is_extra' => $item->is_extra,
+                    ]),
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/V1/Driver/AddExtraSaleRequest.php
+++ b/app/Http/Requests/Api/V1/Driver/AddExtraSaleRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Driver;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class AddExtraSaleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.product_id' => ['required', 'uuid', 'exists:products,id'],
+            'items.*.quantity' => ['required', 'integer', 'min:1'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'items.required' => 'Los items son obligatorios.',
+            'items.array' => 'Los items deben ser un arreglo.',
+            'items.min' => 'Debe haber al menos un item.',
+            'items.*.product_id.required' => 'El ID del producto es obligatorio.',
+            'items.*.product_id.uuid' => 'El ID del producto debe ser un UUID válido.',
+            'items.*.product_id.exists' => 'El producto no existe.',
+            'items.*.quantity.required' => 'La cantidad es obligatoria.',
+            'items.*.quantity.integer' => 'La cantidad debe ser un número entero.',
+            'items.*.quantity.min' => 'La cantidad debe ser al menos 1.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'status' => 'error',
+                'message' => 'Error de validación.',
+                'data' => null,
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Models/ExtraSaleAllocation.php
+++ b/app/Models/ExtraSaleAllocation.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExtraSaleAllocation extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'store_id',
+        'route_id',
+        'destination_stop_id',
+        'destination_stop_item_id',
+        'source_stop_item_id',
+        'quantity',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quantity' => 'integer',
+        ];
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function route(): BelongsTo
+    {
+        return $this->belongsTo(DeliveryRoute::class, 'route_id');
+    }
+
+    public function destinationStop(): BelongsTo
+    {
+        return $this->belongsTo(RouteStop::class, 'destination_stop_id');
+    }
+
+    public function destinationStopItem(): BelongsTo
+    {
+        return $this->belongsTo(RouteStopItem::class, 'destination_stop_item_id');
+    }
+
+    public function sourceStopItem(): BelongsTo
+    {
+        return $this->belongsTo(RouteStopItem::class, 'source_stop_item_id');
+    }
+
+    public function scopeForStore(Builder $query, string $storeId): Builder
+    {
+        return $query->where('store_id', $storeId);
+    }
+
+    public function scopeForRoute(Builder $query, string $routeId): Builder
+    {
+        return $query->where('route_id', $routeId);
+    }
+}

--- a/app/Models/RouteStopItem.php
+++ b/app/Models/RouteStopItem.php
@@ -22,6 +22,7 @@ class RouteStopItem extends Model
         'quantity_planned',
         'quantity_loaded',
         'quantity_delivered',
+        'is_extra',
     ];
 
     protected function casts(): array
@@ -30,6 +31,7 @@ class RouteStopItem extends Model
             'quantity_planned' => 'integer',
             'quantity_loaded' => 'integer',
             'quantity_delivered' => 'integer',
+            'is_extra' => 'boolean',
         ];
     }
 

--- a/app/OpenApi/Schemas/Driver/AvailableSurplusSchema.php
+++ b/app/OpenApi/Schemas/Driver/AvailableSurplusSchema.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\OpenApi\Schemas\Driver;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'AvailableSurplus',
+    title: 'AvailableSurplus',
+    description: 'Producto con excedente disponible en la ruta'
+)]
+class AvailableSurplusSchema
+{
+    #[OA\Property(format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')]
+    public string $product_id;
+
+    #[OA\Property(example: 'Leche entera 1L')]
+    public string $product_name;
+
+    #[OA\Property(example: 'LECHE001')]
+    public string $sku;
+
+    #[OA\Property(format: 'double', example: 150.00)]
+    public float $unit_price;
+
+    #[OA\Property(type: 'integer', example: 5)]
+    public int $available_quantity;
+}

--- a/app/OpenApi/Schemas/Driver/ExtraSaleItemSchema.php
+++ b/app/OpenApi/Schemas/Driver/ExtraSaleItemSchema.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\OpenApi\Schemas\Driver;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ExtraSaleItem',
+    title: 'ExtraSaleItem',
+    description: 'Item de venta extra agregado a una parada'
+)]
+class ExtraSaleItemSchema
+{
+    #[OA\Property(format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')]
+    public string $id;
+
+    #[OA\Property(format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440001')]
+    public string $product_id;
+
+    #[OA\Property(example: 'Leche entera 1L')]
+    public string $product_name;
+
+    #[OA\Property(type: 'integer', example: 3)]
+    public int $quantity_planned;
+
+    #[OA\Property(type: 'integer', example: 3)]
+    public int $quantity_loaded;
+
+    #[OA\Property(type: 'integer', example: 3)]
+    public int $quantity_delivered;
+
+    #[OA\Property(type: 'boolean', example: true)]
+    public bool $is_extra;
+}

--- a/app/Services/DriverExecutionService.php
+++ b/app/Services/DriverExecutionService.php
@@ -2,8 +2,12 @@
 
 namespace App\Services;
 
+use App\Models\CommercialOperation;
 use App\Models\DeliveryRoute;
 use App\Models\DeliveryRouteEvent;
+use App\Models\ExtraSaleAllocation;
+use App\Models\OperationItem;
+use App\Models\Product;
 use App\Models\RouteStop;
 use App\Models\RouteStopCollection;
 use App\Models\RouteStopItem;
@@ -36,6 +40,297 @@ class DriverExecutionService
                 'stops.order.payments.storePaymentMethod.paymentMethod',
             ])
             ->first();
+    }
+
+    /**
+     * Get available surplus products on the truck from completed/failed stops.
+     * available_surplus = SUM(quantity_loaded - quantity_delivered) - SUM(extra_sale_allocations.quantity)
+     */
+    public function getAvailableSurplus(string $routeId, string $storeId): array
+    {
+        $route = DeliveryRoute::where('id', $routeId)
+            ->where('store_id', $storeId)
+            ->where('status', 'dispatched')
+            ->first();
+
+        if (! $route) {
+            throw $this->notFoundError('Ruta no encontrada o no está en estado despachado.');
+        }
+
+        // Get all stop items from completed/failed stops
+        $sourceItems = RouteStopItem::whereHas('routeStop', function ($query) use ($routeId) {
+            $query->where('route_id', $routeId)
+                ->whereIn('status', ['completed', 'failed']);
+        })
+            ->with('product')
+            ->get();
+
+        // Group by product and calculate surplus per product
+        $surplusByProduct = [];
+
+        foreach ($sourceItems as $item) {
+            $productId = $item->product_id;
+            $rawSurplus = $item->quantity_loaded - $item->quantity_delivered;
+
+            if ($rawSurplus <= 0) {
+                continue;
+            }
+
+            if (! isset($surplusByProduct[$productId])) {
+                $surplusByProduct[$productId] = [
+                    'product_id' => $productId,
+                    'product_name' => $item->product?->name,
+                    'sku' => $item->product?->sku,
+                    'unit_price' => (float) ($item->product?->price ?? 0),
+                    'total_surplus' => 0,
+                    'allocated' => 0,
+                ];
+            }
+
+            $surplusByProduct[$productId]['total_surplus'] += $rawSurplus;
+        }
+
+        // Subtract already allocated quantities from extra_sale_allocations
+        $allocations = ExtraSaleAllocation::where('route_id', $routeId)
+            ->select('source_stop_item_id', 'quantity')
+            ->get();
+
+        $sourceItemIds = $sourceItems->pluck('id')->toArray();
+        $allocatedBySourceItem = [];
+
+        foreach ($allocations as $allocation) {
+            if (in_array($allocation->source_stop_item_id, $sourceItemIds)) {
+                if (! isset($allocatedBySourceItem[$allocation->source_stop_item_id])) {
+                    $allocatedBySourceItem[$allocation->source_stop_item_id] = 0;
+                }
+                $allocatedBySourceItem[$allocation->source_stop_item_id] += $allocation->quantity;
+            }
+        }
+
+        // Map allocated quantities back to products
+        foreach ($sourceItems as $item) {
+            $productId = $item->product_id;
+            if (isset($allocatedBySourceItem[$item->id])) {
+                $surplusByProduct[$productId]['allocated'] += $allocatedBySourceItem[$item->id];
+            }
+        }
+
+        // Filter to only products with positive available quantity
+        $result = [];
+        foreach ($surplusByProduct as $productData) {
+            $available = $productData['total_surplus'] - $productData['allocated'];
+            if ($available > 0) {
+                $result[] = [
+                    'product_id' => $productData['product_id'],
+                    'product_name' => $productData['product_name'],
+                    'sku' => $productData['sku'],
+                    'unit_price' => $productData['unit_price'],
+                    'available_quantity' => $available,
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Add extra sale items to a pending/arrived stop.
+     * Automatically allocates from source items with available surplus.
+     */
+    public function addExtraSale(string $stopId, array $items, User $driver): RouteStop
+    {
+        return DB::transaction(function () use ($stopId, $items, $driver) {
+            $stop = RouteStop::with('route')->find($stopId);
+
+            if (! $stop) {
+                throw $this->notFoundError('Parada no encontrada.');
+            }
+
+            $route = $stop->route;
+
+            if ($route->driver_id !== $driver->id) {
+                throw $this->notFoundError('Esta parada no pertenece a una ruta asignada a este conductor.');
+            }
+
+            if ($route->store_id !== $driver->store_id) {
+                throw $this->notFoundError('La parada no pertenece a la tienda del conductor.');
+            }
+
+            if ($route->status !== 'dispatched') {
+                throw $this->validationError('La ruta no está en estado despachado.');
+            }
+
+            if (! in_array($stop->status, ['pending', 'arrived'])) {
+                throw $this->validationError('Solo se pueden agregar ventas extra a paradas pendientes o arrivals.');
+            }
+
+            // Lock route for update to prevent race conditions
+            $route = DeliveryRoute::where('id', $route->id)->lockForUpdate()->first();
+            $stop = RouteStop::where('id', $stopId)->lockForUpdate()->first();
+
+            // Validate and process each item
+            foreach ($items as $itemData) {
+                $productId = $itemData['product_id'];
+                $quantity = (int) $itemData['quantity'];
+
+                if ($quantity <= 0) {
+                    throw $this->validationError("La cantidad debe ser mayor a 0 para el producto {$productId}.");
+                }
+
+                // Get available surplus for this product
+                $availableSurplus = $this->getAvailableSurplusForProduct($route->id, $productId);
+
+                if ($quantity > $availableSurplus) {
+                    throw $this->validationError(
+                        "Cantidad solicitada ({$quantity}) excede el excedente disponible ({$availableSurplus}) para el producto {$productId}."
+                    );
+                }
+
+                // Find source items with available surplus and distribute allocation
+                $remainingToAllocate = $quantity;
+                $sourceItems = $this->getSourceItemsWithSurplus($route->id, $productId);
+
+                foreach ($sourceItems as $sourceItem) {
+                    if ($remainingToAllocate <= 0) {
+                        break;
+                    }
+
+                    $itemSurplus = $sourceItem->quantity_loaded - $sourceItem->quantity_delivered;
+                    $alreadyAllocated = ExtraSaleAllocation::where('source_stop_item_id', $sourceItem->id)
+                        ->sum('quantity');
+                    $availableOnThisItem = $itemSurplus - $alreadyAllocated;
+
+                    if ($availableOnThisItem <= 0) {
+                        continue;
+                    }
+
+                    $toAllocate = min($remainingToAllocate, $availableOnThisItem);
+
+                    // Get product for price
+                    $product = Product::find($productId);
+                    $unitPrice = (float) ($product?->price ?? 0);
+
+                    // Create the destination RouteStopItem (extra sale)
+                    $destStopItem = RouteStopItem::create([
+                        'route_stop_id' => $stop->id,
+                        'product_id' => $productId,
+                        'product_name' => $product?->name,
+                        'quantity_planned' => $toAllocate,
+                        'quantity_loaded' => $toAllocate,
+                        'quantity_delivered' => $toAllocate,
+                        'is_extra' => true,
+                    ]);
+
+                    // Create the allocation record
+                    ExtraSaleAllocation::create([
+                        'store_id' => $route->store_id,
+                        'route_id' => $route->id,
+                        'destination_stop_id' => $stop->id,
+                        'destination_stop_item_id' => $destStopItem->id,
+                        'source_stop_item_id' => $sourceItem->id,
+                        'quantity' => $toAllocate,
+                    ]);
+
+                    // Add OperationItem to the CommercialOperation (order)
+                    $order = $stop->order;
+                    if ($order) {
+                        OperationItem::create([
+                            'operation_id' => $order->id,
+                            'product_id' => $productId,
+                            'product_name' => $product?->name,
+                            'quantity' => $toAllocate,
+                            'price' => $unitPrice,
+                            'subtotal' => $toAllocate * $unitPrice,
+                        ]);
+                    }
+
+                    $remainingToAllocate -= $toAllocate;
+                }
+
+                if ($remainingToAllocate > 0) {
+                    throw $this->validationError(
+                        "No se pudo allocating toda la cantidad solicitada para el producto {$productId}."
+                    );
+                }
+            }
+
+            // Recalculate CommercialOperation totals
+            $order = $stop->order;
+            if ($order) {
+                $this->recalculateOperationTotals($order);
+            }
+
+            return $stop->fresh([
+                'items.product',
+                'order.customer',
+                'order.items',
+                'order.payments',
+            ]);
+        });
+    }
+
+    /**
+     * Get available surplus quantity for a specific product on a route.
+     */
+    private function getAvailableSurplusForProduct(string $routeId, string $productId): int
+    {
+        $sourceItems = RouteStopItem::whereHas('routeStop', function ($query) use ($routeId) {
+            $query->where('route_id', $routeId)
+                ->whereIn('status', ['completed', 'failed']);
+        })
+            ->where('product_id', $productId)
+            ->get();
+
+        $totalSurplus = 0;
+        foreach ($sourceItems as $item) {
+            $totalSurplus += $item->quantity_loaded - $item->quantity_delivered;
+        }
+
+        $allocated = ExtraSaleAllocation::where('route_id', $routeId)
+            ->whereIn('source_stop_item_id', $sourceItems->pluck('id'))
+            ->sum('quantity');
+
+        return max(0, $totalSurplus - $allocated);
+    }
+
+    /**
+     * Get source route stop items that have surplus for a product.
+     */
+    private function getSourceItemsWithSurplus(string $routeId, string $productId): \Illuminate\Database\Eloquent\Collection
+    {
+        $sourceItems = RouteStopItem::whereHas('routeStop', function ($query) use ($routeId) {
+            $query->where('route_id', $routeId)
+                ->whereIn('status', ['completed', 'failed']);
+        })
+            ->where('product_id', $productId)
+            ->get();
+
+        // Filter to only items with available surplus
+        return $sourceItems->filter(function ($item) {
+            $surplus = $item->quantity_loaded - $item->quantity_delivered;
+            $allocated = ExtraSaleAllocation::where('source_stop_item_id', $item->id)->sum('quantity');
+            return ($surplus - $allocated) > 0;
+        })->values();
+    }
+
+    /**
+     * Recalculate and update CommercialOperation totals based on its items.
+     */
+    private function recalculateOperationTotals(CommercialOperation $order): void
+    {
+        $order = CommercialOperation::where('id', $order->id)->lockForUpdate()->first();
+
+        $subtotal = (float) $order->items()->sum(DB::raw('quantity * price'));
+        $tax = (float) $order->items()->sum('tax_amount');
+        $discount = (float) $order->items()->sum('discount_amount');
+        $total = $subtotal + $tax - $discount;
+
+        $order->update([
+            'subtotal' => $subtotal,
+            'tax' => $tax,
+            'discount' => $discount,
+            'total' => $total,
+        ]);
     }
 
     /**

--- a/app/Services/RouteManagementService.php
+++ b/app/Services/RouteManagementService.php
@@ -1163,6 +1163,12 @@ class RouteManagementService
             'events' => fn ($q) => $q->orderBy('created_at'),
         ]);
 
+        // Load extra sale allocations for this route to adjust pending returns
+        $allocations = \App\Models\ExtraSaleAllocation::where('route_id', $route->id)->get();
+        $allocatedBySourceItem = $allocations->groupBy('source_stop_item_id')
+            ->map(fn ($group) => $group->sum('quantity'))
+            ->toArray();
+
         $declaredAmount = 0;
         $verifiedAmount = 0;
         $rejectedAmount = 0;
@@ -1177,7 +1183,10 @@ class RouteManagementService
             $stopHasUnresolved = false;
 
             foreach ($stop->items as $item) {
-                $diff = $item->quantity_loaded - $item->quantity_delivered;
+                $rawDiff = $item->quantity_loaded - $item->quantity_delivered;
+                // Subtract quantities already reallocated via extra_sale_allocations
+                $allocatedQty = $allocatedBySourceItem[$item->id] ?? 0;
+                $diff = $rawDiff - $allocatedQty;
                 $discrepancy = $item->discrepancy ?? null;
 
                 $stopItems[] = [
@@ -1187,6 +1196,7 @@ class RouteManagementService
                     'quantity_loaded' => $item->quantity_loaded,
                     'quantity_delivered' => $item->quantity_delivered,
                     'difference' => $diff,
+                    'extra_sale_allocated' => $allocatedQty,
                     'discrepancy' => $discrepancy ? [
                         'id' => $discrepancy->id,
                         'resolution_type' => $discrepancy->resolution_type,

--- a/database/migrations/2026_08_22_000001_create_extra_sale_allocations_table.php
+++ b/database/migrations/2026_08_22_000001_create_extra_sale_allocations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('extra_sale_allocations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('store_id');
+            $table->uuid('route_id');
+            $table->uuid('destination_stop_id');
+            $table->uuid('destination_stop_item_id');
+            $table->uuid('source_stop_item_id');
+            $table->unsignedInteger('quantity');
+            $table->timestamps();
+
+            $table->foreign('store_id')->references('id')->on('stores')->onDelete('restrict');
+            $table->foreign('route_id')->references('id')->on('delivery_routes')->onDelete('cascade');
+            $table->foreign('destination_stop_id')->references('id')->on('route_stops')->onDelete('cascade');
+            $table->foreign('destination_stop_item_id')->references('id')->on('route_stop_items')->onDelete('cascade');
+            $table->foreign('source_stop_item_id')->references('id')->on('route_stop_items')->onDelete('cascade');
+
+            $table->index(['route_id', 'source_stop_item_id']);
+            $table->index(['destination_stop_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('extra_sale_allocations');
+    }
+};

--- a/database/migrations/2026_08_22_000002_add_is_extra_to_route_stop_items_table.php
+++ b/database/migrations/2026_08_22_000002_add_is_extra_to_route_stop_items_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('route_stop_items', function (Blueprint $table) {
+            $table->boolean('is_extra')->default(false)->after('quantity_delivered');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('route_stop_items', function (Blueprint $table) {
+            $table->dropColumn('is_extra');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\V1\Admin\UserController;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\CatalogsController;
 use App\Http\Controllers\Api\V1\Driver\DriverExecutionController;
+use App\Http\Controllers\Api\V1\Driver\DriverExtraSaleController;
 use App\Http\Controllers\Api\V1\Driver\DriverRouteController;
 use App\Http\Controllers\Api\V1\Driver\DriverStopController;
 use App\Http\Controllers\Api\V1\GeocodingController;
@@ -57,6 +58,8 @@ Route::prefix('v1')->group(function () {
     Route::post('stops/{stop}/complete', [DriverExecutionController::class, 'complete']);
     Route::get('routes/{route}/stops', [DriverRouteController::class, 'stops']);
     Route::get('stops/{stop}', [DriverStopController::class, 'show']);
+    Route::get('routes/{route}/available-surplus', [DriverExtraSaleController::class, 'availableSurplus']);
+    Route::post('stops/{stop}/extra-sales', [DriverExtraSaleController::class, 'addExtraSale']);
     Route::get('payment-methods', [StorePaymentMethodController::class, 'index'])
       ->name('store.payment-methods.index');
     Route::get('rejection-reasons', [RejectionReasonController::class, 'index'])

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -7838,6 +7838,214 @@
                 ]
             }
         },
+        "/driver/routes/{route}/available-surplus": {
+            "get": {
+                "tags": [
+                    "Driver"
+                ],
+                "summary": "Obtener excedentes disponibles en la ruta",
+                "description": "Get available surplus products on the route from completed/failed stops.",
+                "operationId": "b170a4c3ed062f16985c71833027967d",
+                "parameters": [
+                    {
+                        "name": "route",
+                        "in": "path",
+                        "description": "ID de la ruta",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Excedentes disponibles obtenidos correctamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Excedentes disponibles obtenidos correctamente."
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "route_id": {
+                                                    "type": "string",
+                                                    "format": "uuid"
+                                                },
+                                                "surplus": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/AvailableSurplus"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ruta no encontrada o no está en estado despachado"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/driver/stops/{stop}/extra-sales": {
+            "post": {
+                "tags": [
+                    "Driver"
+                ],
+                "summary": "Agregar venta extra a una parada",
+                "description": "Add extra sale items to a pending/arrived stop.",
+                "operationId": "e06736c567db6591538cd3f5b891d04d",
+                "parameters": [
+                    {
+                        "name": "stop",
+                        "in": "path",
+                        "description": "ID del RouteStop",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "items"
+                                ],
+                                "properties": {
+                                    "items": {
+                                        "type": "array",
+                                        "items": {
+                                            "required": [
+                                                "product_id",
+                                                "quantity"
+                                            ],
+                                            "properties": {
+                                                "product_id": {
+                                                    "type": "string",
+                                                    "format": "uuid",
+                                                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                                                },
+                                                "quantity": {
+                                                    "type": "integer",
+                                                    "minimum": 1,
+                                                    "example": 3
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Venta extra agregada correctamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Venta extra agregada correctamente."
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "stop": {
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string",
+                                                            "format": "uuid"
+                                                        },
+                                                        "route_id": {
+                                                            "type": "string",
+                                                            "format": "uuid"
+                                                        },
+                                                        "sequence": {
+                                                            "type": "integer"
+                                                        },
+                                                        "status": {
+                                                            "type": "string"
+                                                        },
+                                                        "order": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string",
+                                                                    "format": "uuid"
+                                                                },
+                                                                "operation_number": {
+                                                                    "type": "string"
+                                                                },
+                                                                "total": {
+                                                                    "type": "number"
+                                                                },
+                                                                "pending_balance": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "nullable": true
+                                                        },
+                                                        "items": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/ExtraSaleItem"
+                                                            }
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Parada o ruta no encontrada"
+                    },
+                    "422": {
+                        "description": "Error de validación - cantidad excede disponible o stop no está en estado válido"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/driver/routes/{route_id}/stops": {
             "get": {
                 "tags": [
@@ -17484,6 +17692,14 @@
                         "type": "string",
                         "format": "uuid",
                         "nullable": true
+                    },
+                    "route_ids": {
+                        "description": "IDs de rutas activas (no canceladas) donde está asignado este pedido",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
                     }
                 },
                 "type": "object"
@@ -17643,6 +17859,14 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/CommercialOperationEventResource"
+                        }
+                    },
+                    "route_ids": {
+                        "description": "IDs de rutas activas (no canceladas) donde está asignado este pedido",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
                         }
                     }
                 },
@@ -18181,6 +18405,35 @@
                 },
                 "type": "object"
             },
+            "AvailableSurplus": {
+                "title": "AvailableSurplus",
+                "description": "Producto con excedente disponible en la ruta",
+                "properties": {
+                    "product_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "product_name": {
+                        "type": "string",
+                        "example": "Leche entera 1L"
+                    },
+                    "sku": {
+                        "type": "string",
+                        "example": "LECHE001"
+                    },
+                    "unit_price": {
+                        "type": "number",
+                        "format": "double",
+                        "example": 150
+                    },
+                    "available_quantity": {
+                        "type": "integer",
+                        "example": 5
+                    }
+                },
+                "type": "object"
+            },
             "DriverActiveRoute": {
                 "title": "DriverActiveRoute",
                 "description": "Ruta activa del conductor con vehiculo, conductor y paradas",
@@ -18296,6 +18549,43 @@
                             }
                         ],
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "ExtraSaleItem": {
+                "title": "ExtraSaleItem",
+                "description": "Item de venta extra agregado a una parada",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "product_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "product_name": {
+                        "type": "string",
+                        "example": "Leche entera 1L"
+                    },
+                    "quantity_planned": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "quantity_loaded": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "quantity_delivered": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "is_extra": {
+                        "type": "boolean",
+                        "example": true
                     }
                 },
                 "type": "object"

--- a/tests/Feature/Api/V1/Driver/DriverStopsTest.php
+++ b/tests/Feature/Api/V1/Driver/DriverStopsTest.php
@@ -158,9 +158,9 @@ test('driver routes stops returns 200 with correct structure for assigned driver
         ->assertJsonPath('data.0.id', $data['stops'][0]->id)
         ->assertJsonPath('data.0.sequence', 1)
         ->assertJsonPath('data.0.status', 'pending')
-        ->assertJsonPath('data.0.address', 'Av. Corrientes 1234')
-        ->assertJsonPath('data.0.contact_name', 'Juan Pérez')
-        ->assertJsonPath('data.0.contact_phone', '+5491155551234')
+        ->assertJsonPath('data.0.address.street', 'Av. Corrientes 1234')
+        ->assertJsonPath('data.0.customer.name', 'Juan Pérez')
+        ->assertJsonPath('data.0.customer.phone', '+5491155551234')
         ->assertJsonStructure([
             'status',
             'data' => [
@@ -168,13 +168,11 @@ test('driver routes stops returns 200 with correct structure for assigned driver
                     'id',
                     'sequence',
                     'status',
-                    'address',
-                    'contact_name',
-                    'contact_phone',
+                    'customer' => ['name', 'phone'],
+                    'address' => ['street', 'locality', 'latitude', 'longitude', 'notes'],
                     'notification_window_start',
                     'notification_window_end',
-                    'items_count',
-                    'total_planned_items',
+                    'order' => ['total', 'paid_amount', 'pending_amount'],
                 ],
             ],
             'errors',


### PR DESCRIPTION
- Added DriverExtraSaleController for handling extra sales related to route stops.
- Created AddExtraSaleRequest for validating extra sale requests.
- Introduced ExtraSaleAllocation model and migration for tracking extra sale allocations.
- Updated RouteStopItem model to include 'is_extra' field.
- Enhanced DriverExecutionService to manage available surplus and extra sales allocation logic.
- Updated API documentation to include new endpoints for available surplus and extra sales.